### PR TITLE
Add audio pipeline_passthru example (AUD-623)

### DIFF
--- a/examples/filter/pipeline_passthru/Makefile
+++ b/examples/filter/pipeline_passthru/Makefile
@@ -1,0 +1,2 @@
+PROJECT_NAME := passthru
+include $(ADF_PATH)/project.mk

--- a/examples/filter/pipeline_passthru/README.md
+++ b/examples/filter/pipeline_passthru/README.md
@@ -1,0 +1,14 @@
+# Audio passthru
+
+This demo passes audio received at the aux_in port to the headphone and speaker outputs.
+
+Typical use cases:
+
+- Exercising the audio pipeline from end to end when bringing up new hardware.
+- Checking for left and right channel consistency through the audio path.
+- Used in conjunction with an audio test set to measure THD+N, for production line testing or performance evaluation.
+
+To run this example you need ESP32 LyraT or compatible board:
+
+- Connect speakers or headphones to the board. 
+- Connect audio source to aux_in.

--- a/examples/filter/pipeline_passthru/main/component.mk
+++ b/examples/filter/pipeline_passthru/main/component.mk
@@ -1,0 +1,3 @@
+#
+# Main Makefile. This is basically the same as a component makefile.
+#

--- a/examples/filter/pipeline_passthru/main/passthru.c
+++ b/examples/filter/pipeline_passthru/main/passthru.c
@@ -1,0 +1,101 @@
+/* Audio passthru
+
+   This example code is in the Public Domain (or CC0 licensed, at your option.)
+
+   Unless required by applicable law or agreed to in writing, this
+   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+#include <string.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "audio_pipeline.h"
+#include "i2s_stream.h"
+#include "audio_hal.h"
+
+static const char *TAG = "PASSTHRU";
+
+void app_main(void)
+{
+    audio_pipeline_handle_t pipeline;
+    audio_element_handle_t i2s_stream_writer, i2s_stream_reader;
+
+    esp_log_level_set("*", ESP_LOG_INFO);
+    esp_log_level_set(TAG, ESP_LOG_DEBUG);
+
+    ESP_LOGI(TAG, "[ 1 ] Start codec chip");
+    audio_hal_codec_config_t audio_hal_codec_cfg =  AUDIO_HAL_ES8388_DEFAULT();
+    audio_hal_codec_cfg.adc_input = AUDIO_HAL_ADC_INPUT_LINE2;
+    audio_hal_codec_cfg.i2s_iface.samples = AUDIO_HAL_44K_SAMPLES;
+    audio_hal_handle_t hal = audio_hal_init(&audio_hal_codec_cfg, 0);
+    audio_hal_ctrl_codec(hal, AUDIO_HAL_CODEC_MODE_BOTH, AUDIO_HAL_CTRL_START);
+
+    ESP_LOGI(TAG, "[ 2 ] Create audio pipeline for playback");
+    audio_pipeline_cfg_t pipeline_cfg = DEFAULT_AUDIO_PIPELINE_CONFIG();
+    pipeline = audio_pipeline_init(&pipeline_cfg);
+
+    ESP_LOGI(TAG, "[3.1] Create i2s stream to write data to codec chip");
+    i2s_stream_cfg_t i2s_cfg = I2S_STREAM_CFG_DEFAULT();
+    i2s_cfg.type = AUDIO_STREAM_WRITER;
+    i2s_stream_writer = i2s_stream_init(&i2s_cfg);
+
+    ESP_LOGI(TAG, "[3.2] Create i2s stream to read data from codec chip");
+    i2s_stream_cfg_t i2s_cfg_read = I2S_STREAM_CFG_DEFAULT();
+    i2s_cfg_read.type = AUDIO_STREAM_READER;
+    i2s_stream_reader = i2s_stream_init(&i2s_cfg_read);
+
+    ESP_LOGI(TAG, "[3.3] Register all elements to audio pipeline");
+    audio_pipeline_register(pipeline, i2s_stream_reader, "i2s_read");
+    audio_pipeline_register(pipeline, i2s_stream_writer, "i2s_write");
+
+    ESP_LOGI(TAG, "[3.4] Link it together [codec_chip]-->i2s_stream_reader-->i2s_stream_writer-->[codec_chip]");
+    audio_pipeline_link(pipeline, (const char *[]) {"i2s_read", "i2s_write"}, 2);
+
+    ESP_LOGI(TAG, "[ 4 ] Setup event listener");
+    audio_event_iface_cfg_t evt_cfg = AUDIO_EVENT_IFACE_DEFAULT_CFG();
+    audio_event_iface_handle_t evt = audio_event_iface_init(&evt_cfg);
+
+    ESP_LOGI(TAG, "[4.1] Listening event from all elements of pipeline");
+    audio_pipeline_set_listener(pipeline, evt);
+
+    ESP_LOGI(TAG, "[ 5 ] Start audio_pipeline");
+    audio_pipeline_run(pipeline);
+
+    ESP_LOGI(TAG, "[ 6 ] Listen for all pipeline events");
+    while (1) {
+        audio_event_iface_msg_t msg;
+        esp_err_t ret = audio_event_iface_listen(evt, &msg, portMAX_DELAY);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "[ * ] Event interface error : %d", ret); 
+            continue;
+        }
+
+        if (msg.cmd == AEL_MSG_CMD_ERROR) {
+            ESP_LOGE(TAG, "[ * ] Action command error: src_type:%d, source:%p cmd:%d, data:%p, data_len:%d",
+                     msg.source_type, msg.source, msg.cmd, msg.data, msg.data_len);
+        }
+
+        /* Stop when the last pipeline element (i2s_stream_writer in this case) receives stop event */
+        if (msg.source_type == AUDIO_ELEMENT_TYPE_ELEMENT && msg.source == (void *) i2s_stream_writer
+                && msg.cmd == AEL_MSG_CMD_REPORT_STATUS && (int) msg.data == AEL_STATUS_STATE_STOPPED) {
+            ESP_LOGW(TAG, "[ * ] Stop event received"); 
+            break;
+        }
+    }
+
+    ESP_LOGI(TAG, "[ 7 ] Stop audio_pipeline");
+    audio_pipeline_terminate(pipeline);
+
+    /* Terminate the pipeline before removing the listener */
+    audio_pipeline_remove_listener(pipeline);
+
+    /* Make sure audio_pipeline_remove_listener & audio_event_iface_remove_listener are called before destroying event_iface */
+    audio_event_iface_destroy(evt);
+
+    /* Release all resources */
+    audio_pipeline_deinit(pipeline);
+    audio_element_deinit(i2s_stream_reader);
+    audio_element_deinit(i2s_stream_writer);
+}


### PR DESCRIPTION
Audio passthru example. Audio present at the auxiliary input is passed to the headphone and speaker output without modification.

I put this in the 'filter' directory as the other directories seemed less appropriate. The current filter example is one of the few examples that does both recording and playback.

Why:-
- Useful to exercise the audio pipeline from end to end when bringing up new hardware.
- Typically used for production line sanity checking and performance checking of the audio signal path by taking THD+N measurements using an Audio test set.
- No existing examples in the ADF using the auxiliary in.
- Useful when checking for left and right channel consistency through audio path.

I have found that audio input on the left and right audio channels appear swapped, both on headphones and speakers. I've not had chance to look into whether this is a problem with the framework, board layout (ESP32_LyraT_V4.2) or something else.