### PR TITLE
Update audio_hal.c correct function name (AUD-1190)

### DIFF
--- a/components/audio_hal/audio_hal.c
+++ b/components/audio_hal/audio_hal.c
@@ -93,7 +93,7 @@ esp_err_t audio_hal_ctrl_codec(audio_hal_handle_t audio_hal, audio_hal_codec_mod
     return ret;
 }
 
-esp_err_t audio_hal_config_iface(audio_hal_handle_t audio_hal, audio_hal_codec_mode_t mode, audio_hal_codec_i2s_iface_t *iface)
+esp_err_t audio_hal_codec_iface_config(audio_hal_handle_t audio_hal, audio_hal_codec_mode_t mode, audio_hal_codec_i2s_iface_t *iface)
 {
     esp_err_t ret = 0;
     AUDIO_HAL_CHECK_NULL(audio_hal, "audio_hal handle is null", -1);


### PR DESCRIPTION
The function audio_hal_config_iface is not the correct name. The documentation and header file specify the function should be audio_hal_codec_iface_config. The function name has been modified to become consistent with header file and documentation.