### PR TITLE
Fix condition syntax (AUD-1293)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ execute_process(COMMAND git describe --always --tags --dirty
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
 add_definitions(-DADF_VER=\"${ADF_VER}\")
 
-if(!IDF_PATH)
+if(NOT DEFINED $ENV{IDF_PATH})
 set(ENV{IDF_PATH} "$ENV{ADF_PATH}/esp-idf/")
 endif()
 set(EXTRA_COMPONENT_DIRS $ENV{ADF_PATH}/components)


### PR DESCRIPTION
`if(!IDF_PATH)` does not check environment variables