### PR TITLE
bugfix periph_wifi (AUD-1376)

### DIFF
--- a/components/esp_peripherals/periph_wifi.c
+++ b/components/esp_peripherals/periph_wifi.c
@@ -295,7 +295,9 @@ static void wifi_reconnect_timer(xTimerHandle tmr)
 {
     esp_periph_handle_t periph = (esp_periph_handle_t)pvTimerGetTimerID(tmr);
     esp_periph_stop_timer(periph);
-    esp_wifi_connect();
+    if (periph_wifi->disable_auto_reconnect != true) {
+        esp_wifi_connect();
+    }
 }
 
 #if defined(ESP_IDF_VERSION)

--- a/components/esp_peripherals/periph_wifi.c
+++ b/components/esp_peripherals/periph_wifi.c
@@ -279,7 +279,7 @@ esp_err_t periph_wifi_config_wait_done(esp_periph_handle_t periph, TickType_t ti
     VALIDATE_WIFI(periph, ESP_FAIL);
     periph_wifi_handle_t periph_wifi = (periph_wifi_handle_t)esp_periph_get_data(periph);
     EventBits_t wificonfig_bit = xEventGroupWaitBits(periph_wifi->state_event,
-        SMARTCONFIG_DONE_BIT | SMARTCONFIG_ERROR_BIT, false, true, tick_to_wait);
+        SMARTCONFIG_DONE_BIT | SMARTCONFIG_ERROR_BIT, false, false, tick_to_wait);
 
     if (wificonfig_bit & SMARTCONFIG_DONE_BIT) {
         return ESP_OK;


### PR DESCRIPTION
在网络重连等待时间内，如果disable_auto_reconnect改变为true，依然会进行重新连接网络。该BUG还会导致smartconfig无法正常运行。
periph_wifi_config_wait_done会永远阻塞。
