### PR TITLE
External I2S pin configuration

### DIFF
--- a/components/audio_board/include/board_pins_config.h
+++ b/components/audio_board/include/board_pins_config.h
@@ -27,6 +27,8 @@
 
 #include "driver/i2c.h"
 #include "driver/i2s.h"
+#include "driver/gpio.h"
+#include "driver/ledc.h"
 #include "driver/spi_common.h"
 #include "driver/spi_master.h"
 #include "driver/spi_slave.h"
@@ -72,12 +74,13 @@ esp_err_t get_i2s_pins(i2s_port_t port, i2s_pin_config_t *i2s_config);
 esp_err_t get_spi_pins(spi_bus_config_t *spi_config, spi_device_interface_config_t *spi_device_interface_config);
 
 /**
- * @brief Set i2s mclk output pin
+ * @brief Enables i2s mclk output pin
  *
  * @note GPIO1 and GPIO3 default are UART pins.
  *
- * @param i2s_num       i2s port index
- * @param gpio_num      gpio number index, only support GPIO0, GPIO1 and GPIO3.
+ * @param i2s_num           i2s port index
+ * @param i2s_config        i2s configuration
+ * @param mclk_gpio_num     mclk gpio number index (only support GPIO0, GPIO1 and GPIO3 with I2S peripheral, others are supported via ledc component)
 
  * @return
  *     - ESP_OK                     Success
@@ -85,7 +88,23 @@ esp_err_t get_spi_pins(spi_bus_config_t *spi_config, spi_device_interface_config
  *     - ESP_ERR_INVALID_STATE      Driver state error
  *     - ESP_ERR_ADF_NOT_SUPPORT    Not support
  */
-esp_err_t i2s_mclk_gpio_select(i2s_port_t i2s_num, gpio_num_t gpio_num);
+esp_err_t i2s_mclk_gpio_enable(i2s_port_t i2s_num, i2s_config_t i2s_config, gpio_num_t mclk_gpio_num);
+
+/**
+ * @brief Disables i2s mclk output pin
+ *
+ * @note GPIO1 and GPIO3 default are UART pins.
+ *
+ * @param i2s_num           i2s port index
+ * @param mclk_gpio_num     MCLK gpio number index
+
+ * @return
+ *     - ESP_OK                     Success
+ *     - ESP_ERR_INVALID_ARG        Parameter error
+ *     - ESP_ERR_INVALID_STATE      Driver state error
+ *     - ESP_ERR_ADF_NOT_SUPPORT    Not support
+ */
+esp_err_t i2s_mclk_gpio_disable(i2s_port_t i2s_num, gpio_num_t mclk_gpio_num);
 
 /**
  * @brief  Get the gpio number for sdcard interrupt

--- a/components/audio_board/lyrat_mini_v1_1/board_pins_config.c
+++ b/components/audio_board/lyrat_mini_v1_1/board_pins_config.c
@@ -85,22 +85,22 @@ esp_err_t get_spi_pins(spi_bus_config_t *spi_config, spi_device_interface_config
     return ESP_OK;
 }
 
-esp_err_t i2s_mclk_gpio_select(i2s_port_t i2s_num, gpio_num_t gpio_num)
+esp_err_t i2s_mclk_gpio_enable(i2s_port_t i2s_num, gpio_num_t mclk_gpio_num)
 {
     if (i2s_num >= I2S_NUM_MAX) {
         ESP_LOGE(TAG, "Does not support i2s number(%d)", i2s_num);
         return ESP_ERR_INVALID_ARG;
     }
-    if (gpio_num != GPIO_NUM_0 && gpio_num != GPIO_NUM_1 && gpio_num != GPIO_NUM_3) {
-        ESP_LOGE(TAG, "Only support GPIO0/GPIO1/GPIO3, gpio_num:%d", gpio_num);
+    if (mclk_gpio_num != GPIO_NUM_0 && mclk_gpio_num != GPIO_NUM_1 && mclk_gpio_num != GPIO_NUM_3) {
+        ESP_LOGE(TAG, "Only support GPIO0/GPIO1/GPIO3, gpio_num:%d", mclk_gpio_num);
         return ESP_ERR_INVALID_ARG;
     }
-    ESP_LOGI(TAG, "I2S%d, MCLK output by GPIO%d", i2s_num, gpio_num);
+    ESP_LOGI(TAG, "I2S%d, MCLK output by GPIO%d", i2s_num, mclk_gpio_num);
     if (i2s_num == I2S_NUM_0) {
-        if (gpio_num == GPIO_NUM_0) {
+        if (mclk_gpio_num == GPIO_NUM_0) {
             PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
             WRITE_PERI_REG(PIN_CTRL, 0xFFF0);
-        } else if (gpio_num == GPIO_NUM_1) {
+        } else if (mclk_gpio_num == GPIO_NUM_1) {
             PIN_FUNC_SELECT(PERIPHS_IO_MUX_U0TXD_U, FUNC_U0TXD_CLK_OUT3);
             WRITE_PERI_REG(PIN_CTRL, 0xF0F0);
         } else {
@@ -108,10 +108,10 @@ esp_err_t i2s_mclk_gpio_select(i2s_port_t i2s_num, gpio_num_t gpio_num)
             WRITE_PERI_REG(PIN_CTRL, 0xFF00);
         }
     } else if (i2s_num == I2S_NUM_1) {
-        if (gpio_num == GPIO_NUM_0) {
+        if (mclk_gpio_num == GPIO_NUM_0) {
             PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
             WRITE_PERI_REG(PIN_CTRL, 0xFFFF);
-        } else if (gpio_num == GPIO_NUM_1) {
+        } else if (mclk_gpio_num == GPIO_NUM_1) {
             PIN_FUNC_SELECT(PERIPHS_IO_MUX_U0TXD_U, FUNC_U0TXD_CLK_OUT3);
             WRITE_PERI_REG(PIN_CTRL, 0xF0FF);
         } else {
@@ -120,6 +120,11 @@ esp_err_t i2s_mclk_gpio_select(i2s_port_t i2s_num, gpio_num_t gpio_num)
         }
     }
     return ESP_OK;
+}
+
+esp_err_t i2s_mclk_gpio_disable(i2s_port_t i2s_num, gpio_num_t mclk_gpio_num)
+{
+	return ESP_OK;
 }
 
 // sdcard

--- a/components/audio_board/lyrat_v4_2/board_pins_config.c
+++ b/components/audio_board/lyrat_v4_2/board_pins_config.c
@@ -79,22 +79,22 @@ esp_err_t get_spi_pins(spi_bus_config_t *spi_config, spi_device_interface_config
     return ESP_OK;
 }
 
-esp_err_t i2s_mclk_gpio_select(i2s_port_t i2s_num, gpio_num_t gpio_num)
+esp_err_t i2s_mclk_gpio_enable(i2s_port_t i2s_num, gpio_num_t mclk_gpio_num)
 {
     if (i2s_num >= I2S_NUM_MAX) {
         ESP_LOGE(TAG, "Does not support i2s number(%d)", i2s_num);
         return ESP_ERR_INVALID_ARG;
     }
-    if (gpio_num != GPIO_NUM_0 && gpio_num != GPIO_NUM_1 && gpio_num != GPIO_NUM_3) {
-        ESP_LOGE(TAG, "Only support GPIO0/GPIO1/GPIO3, gpio_num:%d", gpio_num);
+    if (mclk_gpio_num != GPIO_NUM_0 && mclk_gpio_num != GPIO_NUM_1 && mclk_gpio_num != GPIO_NUM_3) {
+        ESP_LOGE(TAG, "Only support GPIO0/GPIO1/GPIO3, gpio_num:%d", mclk_gpio_num);
         return ESP_ERR_INVALID_ARG;
     }
-    ESP_LOGI(TAG, "I2S%d, MCLK output by GPIO%d", i2s_num, gpio_num);
+    ESP_LOGI(TAG, "I2S%d, MCLK output by GPIO%d", i2s_num, mclk_gpio_num);
     if (i2s_num == I2S_NUM_0) {
-        if (gpio_num == GPIO_NUM_0) {
+        if (mclk_gpio_num == GPIO_NUM_0) {
             PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
             WRITE_PERI_REG(PIN_CTRL, 0xFFF0);
-        } else if (gpio_num == GPIO_NUM_1) {
+        } else if (mclk_gpio_num == GPIO_NUM_1) {
             PIN_FUNC_SELECT(PERIPHS_IO_MUX_U0TXD_U, FUNC_U0TXD_CLK_OUT3);
             WRITE_PERI_REG(PIN_CTRL, 0xF0F0);
         } else {
@@ -102,10 +102,10 @@ esp_err_t i2s_mclk_gpio_select(i2s_port_t i2s_num, gpio_num_t gpio_num)
             WRITE_PERI_REG(PIN_CTRL, 0xFF00);
         }
     } else if (i2s_num == I2S_NUM_1) {
-        if (gpio_num == GPIO_NUM_0) {
+        if (mclk_gpio_num == GPIO_NUM_0) {
             PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
             WRITE_PERI_REG(PIN_CTRL, 0xFFFF);
-        } else if (gpio_num == GPIO_NUM_1) {
+        } else if (mclk_gpio_num == GPIO_NUM_1) {
             PIN_FUNC_SELECT(PERIPHS_IO_MUX_U0TXD_U, FUNC_U0TXD_CLK_OUT3);
             WRITE_PERI_REG(PIN_CTRL, 0xF0FF);
         } else {
@@ -114,6 +114,11 @@ esp_err_t i2s_mclk_gpio_select(i2s_port_t i2s_num, gpio_num_t gpio_num)
         }
     }
     return ESP_OK;
+}
+
+esp_err_t i2s_mclk_gpio_disable(i2s_port_t i2s_num, gpio_num_t mclk_gpio_num)
+{
+	return ESP_OK;
 }
 
 // sdcard

--- a/components/audio_board/lyrat_v4_3/board_pins_config.c
+++ b/components/audio_board/lyrat_v4_3/board_pins_config.c
@@ -79,22 +79,22 @@ esp_err_t get_spi_pins(spi_bus_config_t *spi_config, spi_device_interface_config
     return ESP_OK;
 }
 
-esp_err_t i2s_mclk_gpio_select(i2s_port_t i2s_num, gpio_num_t gpio_num)
+esp_err_t i2s_mclk_gpio_enable(i2s_port_t i2s_num, gpio_num_t mclk_gpio_num)
 {
     if (i2s_num >= I2S_NUM_MAX) {
         ESP_LOGE(TAG, "Does not support i2s number(%d)", i2s_num);
         return ESP_ERR_INVALID_ARG;
     }
-    if (gpio_num != GPIO_NUM_0 && gpio_num != GPIO_NUM_1 && gpio_num != GPIO_NUM_3) {
-        ESP_LOGE(TAG, "Only support GPIO0/GPIO1/GPIO3, gpio_num:%d", gpio_num);
+    if (mclk_gpio_num != GPIO_NUM_0 && mclk_gpio_num != GPIO_NUM_1 && mclk_gpio_num != GPIO_NUM_3) {
+        ESP_LOGE(TAG, "Only support GPIO0/GPIO1/GPIO3, gpio_num:%d", mclk_gpio_num);
         return ESP_ERR_INVALID_ARG;
     }
-    ESP_LOGI(TAG, "I2S%d, MCLK output by GPIO%d", i2s_num, gpio_num);
+    ESP_LOGI(TAG, "I2S%d, MCLK output by GPIO%d", i2s_num, mclk_gpio_num);
     if (i2s_num == I2S_NUM_0) {
-        if (gpio_num == GPIO_NUM_0) {
+        if (mclk_gpio_num == GPIO_NUM_0) {
             PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
             WRITE_PERI_REG(PIN_CTRL, 0xFFF0);
-        } else if (gpio_num == GPIO_NUM_1) {
+        } else if (mclk_gpio_num == GPIO_NUM_1) {
             PIN_FUNC_SELECT(PERIPHS_IO_MUX_U0TXD_U, FUNC_U0TXD_CLK_OUT3);
             WRITE_PERI_REG(PIN_CTRL, 0xF0F0);
         } else {
@@ -102,10 +102,10 @@ esp_err_t i2s_mclk_gpio_select(i2s_port_t i2s_num, gpio_num_t gpio_num)
             WRITE_PERI_REG(PIN_CTRL, 0xFF00);
         }
     } else if (i2s_num == I2S_NUM_1) {
-        if (gpio_num == GPIO_NUM_0) {
+        if (mclk_gpio_num == GPIO_NUM_0) {
             PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
             WRITE_PERI_REG(PIN_CTRL, 0xFFFF);
-        } else if (gpio_num == GPIO_NUM_1) {
+        } else if (mclk_gpio_num == GPIO_NUM_1) {
             PIN_FUNC_SELECT(PERIPHS_IO_MUX_U0TXD_U, FUNC_U0TXD_CLK_OUT3);
             WRITE_PERI_REG(PIN_CTRL, 0xF0FF);
         } else {
@@ -114,6 +114,11 @@ esp_err_t i2s_mclk_gpio_select(i2s_port_t i2s_num, gpio_num_t gpio_num)
         }
     }
     return ESP_OK;
+}
+
+esp_err_t i2s_mclk_gpio_disable(i2s_port_t i2s_num, gpio_num_t mclk_gpio_num)
+{
+	return ESP_OK;
 }
 
 // sdcard

--- a/components/audio_board/lyratd_msc_v2_1/board_pins_config.c
+++ b/components/audio_board/lyratd_msc_v2_1/board_pins_config.c
@@ -77,9 +77,14 @@ esp_err_t get_spi_pins(spi_bus_config_t *spi_config, spi_device_interface_config
     return ESP_OK;
 }
 
-esp_err_t i2s_mclk_gpio_select(i2s_port_t i2s_num, gpio_num_t gpio_num)
+esp_err_t i2s_mclk_gpio_enable(i2s_port_t i2s_num, gpio_num_t mclk_gpio_num)
 {
     return ESP_ERR_ADF_NOT_SUPPORT;
+}
+
+esp_err_t i2s_mclk_gpio_disable(i2s_port_t i2s_num, gpio_num_t mclk_gpio_num)
+{
+	return ESP_ERR_ADF_NOT_SUPPORT;
 }
 
 // sdcard

--- a/components/audio_board/lyratd_msc_v2_2/board_pins_config.c
+++ b/components/audio_board/lyratd_msc_v2_2/board_pins_config.c
@@ -76,9 +76,14 @@ esp_err_t get_spi_pins(spi_bus_config_t *spi_config, spi_device_interface_config
     return ESP_OK;
 }
 
-esp_err_t i2s_mclk_gpio_select(i2s_port_t i2s_num, gpio_num_t gpio_num)
+esp_err_t i2s_mclk_gpio_enable(i2s_port_t i2s_num, gpio_num_t mclk_gpio_num)
 {
     return ESP_ERR_ADF_NOT_SUPPORT;
+}
+
+esp_err_t i2s_mclk_gpio_disable(i2s_port_t i2s_num, gpio_num_t mclk_gpio_num)
+{
+	return ESP_ERR_ADF_NOT_SUPPORT;
 }
 
 // sdcard

--- a/components/audio_hal/test/test_audio_hal.c
+++ b/components/audio_hal/test/test_audio_hal.c
@@ -34,7 +34,8 @@
 #include "zl38063.h"
 
 
-#define TEST_I2S_NUM  I2S_NUM_0
+#define TEST_I2S_NUM		I2S_NUM_0
+#define TEST_I2S_MCLK_GPIO	GPIO_NUM_0
 
 static const char *TAG = "TEST_AUDIO_HAL";
 
@@ -59,11 +60,12 @@ static void i2s_init()
     i2s_pin_config_t i2s_pin_cfg = {0};
     get_i2s_pins(TEST_I2S_NUM, &i2s_pin_cfg);
     i2s_set_pin(TEST_I2S_NUM, &i2s_pin_cfg);
-    i2s_mclk_gpio_select(TEST_I2S_NUM, GPIO_NUM_0);
+    i2s_mclk_gpio_enable(TEST_I2S_NUM, TEST_I2S_MCLK_GPIO);
 }
 
 static void i2s_deinit()
 {
+    i2s_mclk_gpio_disable(TEST_I2S_NUM, TEST_I2S_MCLK_GPIO);
     i2s_driver_uninstall(TEST_I2S_NUM);
 }
 

--- a/components/audio_stream/include/i2s_stream.h
+++ b/components/audio_stream/include/i2s_stream.h
@@ -25,6 +25,7 @@
 #ifndef _I2S_STREAM_WRITER_H_
 #define _I2S_STREAM_WRITER_H_
 
+#include "driver/gpio.h"
 #include "driver/i2s.h"
 #include "audio_common.h"
 #include "audio_error.h"
@@ -41,6 +42,8 @@ typedef struct {
     audio_stream_type_t     type;               /*!< Type of stream */
     i2s_config_t            i2s_config;         /*!< I2S driver configurations */
     i2s_port_t              i2s_port;           /*!< I2S driver hardware port */
+    i2s_pin_config_t        i2s_pin_config;     /*!< I2S pin configurations */
+    gpio_num_t              mclk_gpio_num;      /*!< MCLK gpio number */
     bool                    use_alc;            /*!< It is a flag for ALC. If use ALC, the value is true. Or the value is false */
     int                     volume;             /*!< The volume of audio input data will be set. */
     int                     out_rb_size;        /*!< Size of output ringbuffer */
@@ -76,6 +79,13 @@ typedef struct {
         .tx_desc_auto_clear = true,                                             \
     },                                                                          \
     .i2s_port = 0,                                                              \
+    .i2s_pin_config = {                                                         \
+        .bck_io_num = GPIO_NUM_NC,                                              \
+        .ws_io_num = GPIO_NUM_NC,                                               \
+        .data_out_num = GPIO_NUM_NC,                                            \
+        .data_in_num = GPIO_NUM_NC,                                             \
+    },                                                                          \
+    .mclk_gpio_num = GPIO_NUM_0,                                                \
     .use_alc = false,                                                           \
     .volume = 0,                                                                \
     .multi_out_num = 0,                                                         \


### PR DESCRIPTION
I2S MCLK can be configured on any pin using ledc peripheral (PWM timers) just like esp32-camera does.
I2S pin can be passed on the i2s_stream object: having I2S pins hardcoded into the board get_i2s_pins() funcion can be limiting if you want to support different HW configurations without the need of different binaries (buildling the same fiware with different board enabled).