### PR TITLE
Fix Google TTS example (AUD-2363) (AUD-2935)

### DIFF
--- a/examples/cloud_services/google_translate_device/main/google_sr.c
+++ b/examples/cloud_services/google_translate_device/main/google_sr.c
@@ -257,6 +257,8 @@ esp_err_t google_sr_destroy(google_sr_handle_t sr)
     audio_pipeline_stop(sr->pipeline);
     audio_pipeline_wait_for_stop(sr->pipeline);
     audio_pipeline_terminate(sr->pipeline);
+    audio_pipeline_unregister(sr->pipeline, sr->i2s_reader);
+    audio_pipeline_unregister(sr->pipeline, sr->http_stream_writer);
     audio_pipeline_remove_listener(sr->pipeline);
     audio_pipeline_deinit(sr->pipeline);
     audio_element_deinit(sr->i2s_reader);

--- a/examples/cloud_services/google_translate_device/main/google_tts.c
+++ b/examples/cloud_services/google_translate_device/main/google_tts.c
@@ -208,6 +208,9 @@ esp_err_t google_tts_destroy(google_tts_handle_t tts)
     audio_pipeline_stop(tts->pipeline);
     audio_pipeline_wait_for_stop(tts->pipeline);
     audio_pipeline_terminate(tts->pipeline);
+    audio_pipeline_unregister(tts->pipeline, tts->http_stream_reader);
+    audio_pipeline_unregister(tts->pipeline, tts->i2s_writer);
+    audio_pipeline_unregister(tts->pipeline, tts->mp3_decoder);
     audio_pipeline_remove_listener(tts->pipeline);
     audio_pipeline_deinit(tts->pipeline);
     audio_element_deinit(tts->i2s_writer);


### PR DESCRIPTION
Re-posting PR #468 from a renamed and rebased branch, as requested by @jason-mao.

From the original PR:
> fix link_tag pointer in audio_pipeline_link - this caused the example not to work at all.

This was fixed by @HengYongChao in the meantime.

> I also experienced panic in google_tts_destroy() when trying google_tts code outside of this example. Other examples use audio_pipeline_unregister(), so I've added it here too. google_tts_destroy() now completes successfuly, google_sr_destroy() at least compiles - haven't tested it.

This still seems to be the case.