### PR TITLE
Silence some fallthrough warnings (AUD-3176)

### DIFF
--- a/components/battery_service/battery_service.c
+++ b/components/battery_service/battery_service.c
@@ -120,6 +120,7 @@ static void battery_task(void *pvParameters)
                 }
                 case BATTERY_SERVICE_DESTROY:
                     service->running = false;
+                    __attribute__((fallthrough));
                     // No break, to share the actions of case `BATTERY_SERVICE_STOP`, clear all the monitors.
                 case BATTERY_SERVICE_STOP: {
                     if (service->vol_monitor != NULL) {

--- a/components/ota_service/esp_fs_ota.c
+++ b/components/ota_service/esp_fs_ota.c
@@ -232,6 +232,7 @@ esp_err_t esp_fs_ota_finish(esp_fs_ota_handle_t fs_ota_handle)
         case ESP_FS_OTA_SUCCESS:
         case ESP_FS_OTA_IN_PROGRESS:
             err = esp_ota_end(handle->update_handle);
+            __attribute__((fallthrough));
         case ESP_FS_OTA_BEGIN:
             if (handle->ota_upgrade_buf) {
                 audio_free(handle->ota_upgrade_buf);


### PR DESCRIPTION
You get these warnings with a recent esp-idf version.