### PR TITLE
`esp_blufi_close` moved from 'esp_blufi_api.h' to 'esp_blufi.h' (AUD-3247)

### DIFF
--- a/components/esp_peripherals/lib/blufi/wifibleconfig.c
+++ b/components/esp_peripherals/lib/blufi/wifibleconfig.c
@@ -34,7 +34,11 @@
 #include "esp_bt.h"
 #include "esp_log.h"
 #include "audio_error.h"
+#if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0))
+#include "esp_blufi.h"
+#else
 #include "esp_blufi_api.h"
+#endif
 #include "esp_bt_defs.h"
 #include "esp_gap_ble_api.h"
 #include "esp_bt_device.h"

--- a/components/wifi_service/blufi_config/blufi_config.c
+++ b/components/wifi_service/blufi_config/blufi_config.c
@@ -47,7 +47,11 @@ static const char *TAG = "BLUFI_CONFIG";
 #ifdef CONFIG_BLUEDROID_ENABLED
 
 #include "esp_bt.h"
+#if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0))
+#include "esp_blufi.h"
+#else
 #include "esp_blufi_api.h"
+#endif
 #include "esp_bt_defs.h"
 #include "esp_gap_ble_api.h"
 #include "esp_bt_device.h"


### PR DESCRIPTION
You get compilation errors with a recent esp-idf.