### PR TITLE
a2dp_stream: FIX incorrect/unecessary volume range checks (AUD-3688)

### DIFF
--- a/components/bluetooth_service/a2dp_stream.c
+++ b/components/bluetooth_service/a2dp_stream.c
@@ -516,17 +516,11 @@ static esp_err_t periph_bt_avrc_passthrough_cmd(esp_periph_handle_t periph, uint
     if(s_aadp_handler.avrcp_conn_tg_state) {
         if (cmd == ESP_AVRC_PT_CMD_VOL_DOWN) {
             int16_t volume = (default_volume - 5) < 0 ? 0 : (default_volume - 5);
-            if(volume <= 0){
-                volume = 0;
-            }
             bt_avrc_volume_set_by_local(volume);
             default_volume = volume;
             return err;
         } else if (cmd == ESP_AVRC_PT_CMD_VOL_UP) {
             int16_t volume = (default_volume + 5) > 0x7f ? 0x7f : (default_volume + 5);
-            if(volume >= 100){
-                volume = 100;
-            }
             bt_avrc_volume_set_by_local(volume);
             default_volume = volume;
             return err;


### PR DESCRIPTION
The check that volume is <= 100 is incorrect, as the maximum value for volume should actually be 127 (as it is in the range check on the previous line).

Both of these checks are redundant, as the lines above each that calculate volume already do the range check, preventing values below 0 or above 0x7F (127) respectively.