### PR TITLE
Enables use of internal DAC with most recents ESP-IDF versions (AUD-3821)

### DIFF
--- a/components/audio_stream/i2s_stream.c
+++ b/components/audio_stream/i2s_stream.c
@@ -47,10 +47,10 @@ static const char *TAG = "I2S_STREAM";
 #if (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 2, 0))
 #define SOC_I2S_SUPPORTS_ADC_DAC 1
 #include "driver/dac.h"
-#endif
 
 #else
 #define SOC_I2S_SUPPORTS_ADC_DAC 1
+#endif
 #endif // defined(ESP_IDF_VERSION)
 
 typedef struct i2s_stream {


### PR DESCRIPTION
The component i2s_stream was not working in internal DAC mode with most recent ESP-IDF versions.
A bad closure of the #IF clause that verify de ESP-IDF version was making the constant SOC_I2S_SUPPORTS_ADC_DAC never been set (with recent ESP-IDF versions).