### PR TITLE
Two improvements (AUD-4079)

### DIFF
--- a/components/audio_pipeline/audio_element.c
+++ b/components/audio_pipeline/audio_element.c
@@ -904,7 +904,7 @@ esp_err_t audio_element_wait_for_stop(audio_element_handle_t el)
 {
     if (el->is_running == false) {
         ESP_LOGD(TAG, "[%s] Element already stopped, return without waiting", el->tag);
-        return ESP_FAIL;
+        return ESP_OK;
     }
     EventBits_t uxBits = xEventGroupWaitBits(el->state_event, STOPPED_BIT, false, true, DEFAULT_MAX_WAIT_TIME);
     esp_err_t ret = ESP_ERR_TIMEOUT;

--- a/components/esp_peripherals/periph_wifi.c
+++ b/components/esp_peripherals/periph_wifi.c
@@ -473,8 +473,11 @@ static esp_err_t _wifi_destroy(esp_periph_handle_t self)
     audio_free(periph_wifi);
     g_periph = NULL;
 
+#if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0))
+    ESP_ERROR_CHECK(esp_event_loop_delete_default());
 #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0))
     esp_netif_destroy_default_wifi(sta);
+#endif
 #endif
     return ESP_OK;
 }


### PR DESCRIPTION
* The audio_element_wait_for_stop(audio_element_handle_t el) methodThis method should not fail if the element has already stopped.
* The _wifi_destroy(..) method of the wifi peripheral should stop the default event loop if the peripheral is destroyed. This way the peripheral can be created again later.