### PR TITLE
esp_codec_dev: fixed compiling warning as an external component (AUD-4510)

### DIFF
--- a/components/esp_codec_dev/audio_codec_sw_vol.c
+++ b/components/esp_codec_dev/audio_codec_sw_vol.c
@@ -47,7 +47,7 @@ static int _sw_vol_open(const audio_codec_vol_if_t *h, esp_codec_dev_sample_info
     return ESP_CODEC_DEV_OK;
 }
 
-static int _sw_vol_process(const audio_codec_vol_if_t *h, uint8_t *in, int len, 
+static int _sw_vol_process(const audio_codec_vol_if_t *h, uint8_t *in, int len,
                            uint8_t *out, int out_len)
 {
     audio_vol_t *vol = (audio_vol_t *) h;
@@ -124,7 +124,7 @@ static int _sw_vol_set(const audio_codec_vol_if_t *h, float db_value)
     return ESP_CODEC_DEV_OK;
 }
 
-const audio_codec_vol_if_t *audio_codec_new_sw_vol()
+const audio_codec_vol_if_t *audio_codec_new_sw_vol(void)
 {
     audio_vol_t *vol = calloc(1, sizeof(audio_vol_t));
     if (vol == NULL) {

--- a/components/esp_codec_dev/audio_codec_sw_vol.h
+++ b/components/esp_codec_dev/audio_codec_sw_vol.h
@@ -18,7 +18,7 @@ extern "C" {
  * @return        NULL: Memory not enough
  *                -Others: Software volume interface handle
  */
-const audio_codec_vol_if_t* audio_codec_new_sw_vol();
+const audio_codec_vol_if_t* audio_codec_new_sw_vol(void);
 
 #ifdef __cplusplus
 }

--- a/components/esp_codec_dev/idf_component.yml
+++ b/components/esp_codec_dev/idf_component.yml
@@ -1,4 +1,4 @@
-version: 1.0.1
+version: 1.0.2
 description: Audio codec device support for Espressif SOC
 url: https://github.com/espressif/esp-adf/tree/master/components/esp_codec_dev
 

--- a/components/esp_codec_dev/include/esp_codec_dev_defaults.h
+++ b/components/esp_codec_dev/include/esp_codec_dev_defaults.h
@@ -74,7 +74,7 @@ typedef struct {
  * @return        NULL: Failed
  *                Others: Codec GPIO interface
  */
-const audio_codec_gpio_if_t *audio_codec_new_gpio();
+const audio_codec_gpio_if_t *audio_codec_new_gpio(void);
 
 /**
  * @brief         Get default SPI control interface
@@ -93,7 +93,7 @@ const audio_codec_ctrl_if_t *audio_codec_new_i2c_ctrl(audio_codec_i2c_cfg_t *i2c
 /**
  * @brief         Get default I2S data interface
  * @return        NULL: Failed
- *                Others: I2S data interface    
+ *                Others: I2S data interface
  */
 const audio_codec_data_if_t *audio_codec_new_i2s_data(audio_codec_i2s_cfg_t *i2s_cfg);
 

--- a/components/esp_codec_dev/platform/audio_codec_gpio.c
+++ b/components/esp_codec_dev/platform/audio_codec_gpio.c
@@ -44,7 +44,7 @@ static bool _gpio_get(int16_t gpio)
     return (bool) gpio_get_level((gpio_num_t) gpio);
 }
 
-const audio_codec_gpio_if_t *audio_codec_new_gpio()
+const audio_codec_gpio_if_t *audio_codec_new_gpio(void)
 {
     audio_codec_gpio_if_t *gpio_if = (audio_codec_gpio_if_t *) calloc(1, sizeof(audio_codec_gpio_if_t));
     if (gpio_if == NULL) {


### PR DESCRIPTION
esp_codec_dev: fixed compiling warning `strict-prototypes` as an external component