### PR TITLE
Remove "/sdcard" hardcoded from FATFS stream URI (AUD-4622)

### DIFF
--- a/components/audio_stream/fatfs_stream.c
+++ b/components/audio_stream/fatfs_stream.c
@@ -100,7 +100,7 @@ static esp_err_t _fatfs_open(audio_element_handle_t self)
         return ESP_FAIL;
     }
     ESP_LOGD(TAG, "_fatfs_open, uri:%s", uri);
-    char *path = strstr(uri, "/sdcard");
+    char *path = uri;
     audio_element_getinfo(self, &info);
     if (path == NULL) {
         ESP_LOGE(TAG, "Error, need file path to open");


### PR DESCRIPTION
I noticed that FATFS stream forces the URI to begin with `/sdcard`, which is a bad assumption

In my case, I have mounted an FATFS partition stored on an external SPI flash

This PR is intended to start a discussion for a real fix, but I have verified/tested that this simple fix works too