### PR TITLE
Remove hardcoded mclk I2S pin (AUD-4624)

### DIFF
--- a/components/audio_stream/i2s_stream.c
+++ b/components/audio_stream/i2s_stream.c
@@ -423,7 +423,6 @@ audio_element_handle_t i2s_stream_init(i2s_stream_cfg_t *config)
         get_i2s_pins(i2s->config.i2s_port, &i2s_pin_cfg);
         i2s_set_pin(i2s->config.i2s_port, &i2s_pin_cfg);
     }
-    i2s_mclk_gpio_select(i2s->config.i2s_port, GPIO_NUM_0);
 
     return el;
 }


### PR DESCRIPTION
MCLK is hardcoded to `GPIO_NUM_0`, when it should be using the results from `get_i2s_pins()`