### PR TITLE
sr_recorder: fix recorder_sr_reset_speech_cmd on ESP32-S3 (AUD-4695)

### DIFF
--- a/components/audio_recorder/recorder_sr.c
+++ b/components/audio_recorder/recorder_sr.c
@@ -592,7 +592,7 @@ esp_err_t recorder_sr_reset_speech_cmd(recorder_sr_handle_t handle, char *comman
 
     esp_mn_commands_clear();
 
-    uint8_t cmd_id = 0;
+    uint16_t cmd_id = 0;
     char *cmd_str = NULL;
     char *phrase = NULL;
     strcpy(buf, command_str);


### PR DESCRIPTION
Since ESP-SR commit 62b626f3f642
("Update multinet API to add/modify/print/check new commmand string"), 400 multinet commands are supported on ESP32-S3. The max value for uint8_t is 255, which is lower than 400. This causes the following warning:

/willow/deps/esp-adf/components/audio_recorder/recorder_sr.c: In function 'recorder_sr_reset_speech_cmd': /willow/deps/esp-adf/components/audio_recorder/recorder_sr.c:613:22: warning: comparison is always false due to limited range of data type [-Wtype-limits]
         if (++cmd_id > ESP_MN_MAX_PHRASE_NUM) {
                      ^

Change cmd_id to uint16_t to fix this.