### PR TITLE
Allow setting HTTP User Agent in HTTP stream (AUD-4697)

### DIFF
--- a/components/audio_stream/http_stream.c
+++ b/components/audio_stream/http_stream.c
@@ -100,6 +100,7 @@ typedef struct http_stream {
     int                             request_range_size;
     int64_t                         request_range_end;
     bool                            is_last_range;
+    const char                      *user_agent;
 } http_stream_t;
 
 static esp_err_t http_stream_auto_connect_next_track(audio_element_handle_t el);
@@ -586,6 +587,7 @@ _stream_open_begin:
 #if  (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 3, 0)) && defined CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
             .crt_bundle_attach = http->crt_bundle_attach,
 #endif //  (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 3, 0)) && defined CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
+            .user_agent = http->user_agent,
         };
         http->client = esp_http_client_init(&http_cfg);
         AUDIO_MEM_CHECK(TAG, http->client, return ESP_ERR_NO_MEM);
@@ -870,6 +872,7 @@ audio_element_handle_t http_stream_init(http_stream_cfg_t *config)
     http->stream_type = config->type;
     http->user_data = config->user_data;
     http->cert_pem = config->cert_pem;
+    http->user_agent = config->user_agent;
 
     if (config->crt_bundle_attach) {
 #if  (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 3, 0))

--- a/components/audio_stream/include/http_stream.h
+++ b/components/audio_stream/include/http_stream.h
@@ -94,6 +94,7 @@ typedef struct {
     int                         request_range_size;     /*!< Range size setting for header `Range: bytes=start-end`
                                                              Request full range of resource if set to 0
                                                              Range size bigger than request size is recommended */
+    const char                  *user_agent;            /*!< The User Agent string to send with HTTP requests */
 } http_stream_cfg_t;
 
 #define HTTP_STREAM_TASK_STACK          (6 * 1024)
@@ -115,6 +116,7 @@ typedef struct {
     .multi_out_num = 0,                          \
     .cert_pem  = NULL,                           \
     .crt_bundle_attach = NULL,                   \
+    .user_agent = NULL,                          \
 }
 
 /**


### PR DESCRIPTION
Add a user_agent field to the http_stream and http_stream_cfg_t structs
so people can override the default user agent set by esp_http_client.