### PR TITLE
bluetooth_service: Add function to get connected A2DP device (AUD-4747)

### DIFF
--- a/components/bluetooth_service/include/a2dp_stream.h
+++ b/components/bluetooth_service/include/a2dp_stream.h
@@ -208,6 +208,8 @@ esp_err_t periph_bt_volume_up(esp_periph_handle_t periph);
 esp_err_t periph_bt_volume_down(esp_periph_handle_t periph);
 #endif
 
+esp_err_t periph_bt_get_connected_bd_addr(esp_periph_handle_t periph, uint8_t *dest);
+
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
This is helpful for storing the last known connected device for reconnecting to it on startup.

For example:

```c
            if ((msg.cmd == PERIPH_BLUETOOTH_CONNECTED))
            {
                /* Save this as the last device that was connected */
                nvs_handle_t my_handle;
                esp_err_t err;

                err = nvs_open("storage", NVS_READWRITE, &my_handle);
                ESP_ERROR_CHECK_WITHOUT_ABORT(err);

                esp_bd_addr_t connected_bd_addr;
                periph_bt_get_connected_bd_addr(periph_set_handle, connected_bd_addr);

                err = nvs_set_blob(my_handle, "last_bd_addr", connected_bd_addr, 6);
                ESP_ERROR_CHECK_WITHOUT_ABORT(err);

                err = nvs_commit(my_handle);
                ESP_ERROR_CHECK_WITHOUT_ABORT(err);

                nvs_close(my_handle);
            }
```