### PR TITLE
esp_peripherals: Check if blufi enabled around call to ble_config_start or ble_config_stop (AUD-4749)

### DIFF
--- a/components/esp_peripherals/periph_wifi.c
+++ b/components/esp_peripherals/periph_wifi.c
@@ -87,7 +87,7 @@ esp_err_t periph_wifi_wait_for_connected(esp_periph_handle_t periph, TickType_t 
     if (connected_bit & CONNECTED_BIT) {
         return ESP_OK;
     }
-#if defined(CONFIG_BTDM_CTRL_MODE_BLE_ONLY) || defined(CONFIG_BTDM_CTRL_MODE_BTDM)
+#if defined(CONFIG_BT_BLE_BLUFI_ENABLE)
     if (periph_wifi->config_mode == WIFI_CONFIG_BLUEFI) {
         ble_config_stop();
     }
@@ -256,7 +256,7 @@ esp_err_t periph_wifi_config_start(esp_periph_handle_t periph, periph_wifi_confi
         //todo : add wps
         return ESP_OK;
     } else if (mode == WIFI_CONFIG_BLUEFI) {
-#if defined(CONFIG_BTDM_CTRL_MODE_BLE_ONLY) || defined(CONFIG_BTDM_CTRL_MODE_BTDM)
+#if defined(CONFIG_BT_BLE_BLUFI_ENABLE)
         ble_config_start(periph);
 #endif
         return ESP_OK;


### PR DESCRIPTION
This fixes a link error when controller mode is BLE or BTDM but BLUFI is not enabled