### PR TITLE
Wi-Fi improvements (AUD-4778)

### DIFF
--- a/components/esp_peripherals/periph_wifi.c
+++ b/components/esp_peripherals/periph_wifi.c
@@ -313,6 +313,11 @@ static void _wifi_event_callback(void *arg, esp_event_base_t event_base,
         esp_wifi_get_config(WIFI_IF_STA, &w_config);
         strcpy(periph_wifi->ssid, (char *)w_config.sta.ssid);
     } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+        wifi_event_sta_disconnected_t *event = (wifi_event_sta_disconnected_t *) event_data;
+        if (event->reason == WIFI_REASON_ROAMING) {
+            ESP_LOGI(TAG, "Wi-Fi Station Roaming");
+            return;
+        }
         periph_wifi->wifi_state = PERIPH_WIFI_DISCONNECTED;
         xEventGroupClearBits(periph_wifi->state_event, CONNECTED_BIT);
         xEventGroupSetBits(periph_wifi->state_event, DISCONNECTED_BIT);

--- a/components/esp_peripherals/periph_wifi.c
+++ b/components/esp_peripherals/periph_wifi.c
@@ -23,6 +23,7 @@
  */
 
 #include <string.h>
+#include "sdkconfig.h"
 #include "esp_wpa2.h"
 #include "esp_event.h"
 #include "esp_log.h"
@@ -427,6 +428,12 @@ static esp_err_t _wifi_init(esp_periph_handle_t self)
             strcpy((char *)wifi_config.sta.password, periph_wifi->password);
             ESP_LOGD(TAG, "WIFI_PASS=%s", wifi_config.sta.password);
         }
+
+#if defined(CONFIG_WPA_11KV_SUPPORT)
+        wifi_config.sta.btm_enabled = 1;
+        wifi_config.sta.rm_enabled = 1;
+#endif
+
         ESP_ERROR_CHECK(esp_wifi_set_storage(WIFI_STORAGE_RAM));
         ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
         ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));

--- a/components/esp_peripherals/periph_wifi.c
+++ b/components/esp_peripherals/periph_wifi.c
@@ -433,6 +433,9 @@ static esp_err_t _wifi_init(esp_periph_handle_t self)
         wifi_config.sta.btm_enabled = 1;
         wifi_config.sta.rm_enabled = 1;
 #endif
+#if defined(CONFIG_WPA_MBO_SUPPORT)
+    wifi_config.sta.mbo_enabled = 1;
+#endif
 
         ESP_ERROR_CHECK(esp_wifi_set_storage(WIFI_STORAGE_RAM));
         ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));


### PR DESCRIPTION
* enable 802.11K Radio Resource Management when supported
* enable 802.11V BSS Transitition Management when supported
* don't disconnect on WIFI_REASON_ROAMING event