### PR TITLE
Fix some warnings with ESP-IDF >= 5 (AUD-4923)

### DIFF
--- a/components/audio_stream/include/i2s_stream.h
+++ b/components/audio_stream/include/i2s_stream.h
@@ -149,7 +149,7 @@ typedef struct {
     .need_expand = false,                                                       \
     .expand_src_bits = I2S_BITS_PER_SAMPLE_16BIT,                               \
 }
-#else
+#elif (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0))
 #define I2S_STREAM_CFG_DEFAULT() {                                              \
     .type = AUDIO_STREAM_WRITER,                                                \
     .i2s_config = {                                                             \
@@ -236,6 +236,94 @@ typedef struct {
     .need_expand = false,                                                       \
     .expand_src_bits = I2S_BITS_PER_SAMPLE_16BIT,                               \
 }
+#else
+#define I2S_STREAM_CFG_DEFAULT() {                                              \
+    .type = AUDIO_STREAM_WRITER,                                                \
+    .i2s_config = {                                                             \
+        .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX | I2S_MODE_RX),      \
+        .sample_rate = 44100,                                                   \
+        .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,                           \
+        .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,                           \
+        .communication_format = I2S_COMM_FORMAT_STAND_I2S,                      \
+        .intr_alloc_flags = ESP_INTR_FLAG_LEVEL2 | ESP_INTR_FLAG_IRAM,          \
+        .dma_desc_num = 3,                                                      \
+        .dma_frame_num = 300,                                                   \
+        .use_apll = true,                                                       \
+        .tx_desc_auto_clear = true,                                             \
+        .fixed_mclk = 0                                                         \
+    },                                                                          \
+    .i2s_port = I2S_NUM_0,                                                      \
+    .use_alc = false,                                                           \
+    .volume = 0,                                                                \
+    .out_rb_size = I2S_STREAM_RINGBUFFER_SIZE,                                  \
+    .task_stack = I2S_STREAM_TASK_STACK,                                        \
+    .task_core = I2S_STREAM_TASK_CORE,                                          \
+    .task_prio = I2S_STREAM_TASK_PRIO,                                          \
+    .stack_in_ext = false,                                                      \
+    .multi_out_num = 0,                                                         \
+    .uninstall_drv = true,                                                      \
+    .need_expand = false,                                                       \
+    .expand_src_bits = I2S_BITS_PER_SAMPLE_16BIT,                               \
+    .buffer_len = I2S_STREAM_BUF_SIZE,                                          \
+}
+
+#define I2S_STREAM_INTERNAL_DAC_CFG_DEFAULT() {                                 \
+    .type = AUDIO_STREAM_WRITER,                                                \
+    .i2s_config = {                                                             \
+        .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_DAC_BUILT_IN | I2S_MODE_TX),\
+        .sample_rate = 44100,                                                   \
+        .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,                           \
+        .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,                           \
+        .communication_format = I2S_COMM_FORMAT_STAND_MSB,                        \
+        .intr_alloc_flags = ESP_INTR_FLAG_LEVEL2,                               \
+        .dma_desc_num = 3,                                                      \
+        .dma_frame_num = 300,                                                   \
+        .use_apll = false,                                                      \
+        .tx_desc_auto_clear = true,                                             \
+        .fixed_mclk = 0                                                         \
+    },                                                                          \
+    .i2s_port = I2S_NUM_0,                                                      \
+    .use_alc = false,                                                           \
+    .volume = 0,                                                                \
+    .out_rb_size = I2S_STREAM_RINGBUFFER_SIZE,                                  \
+    .task_stack = I2S_STREAM_TASK_STACK,                                        \
+    .task_core = I2S_STREAM_TASK_CORE,                                          \
+    .task_prio = I2S_STREAM_TASK_PRIO,                                          \
+    .stack_in_ext = false,                                                      \
+    .multi_out_num = 0,                                                         \
+    .uninstall_drv = false,                                                     \
+    .need_expand = false,                                                       \
+    .expand_src_bits = I2S_BITS_PER_SAMPLE_16BIT,                               \
+}
+
+#define I2S_STREAM_TX_PDM_CFG_DEFAULT() {                                       \
+    .type = AUDIO_STREAM_WRITER,                                                \
+    .i2s_config = {                                                             \
+        .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_PDM | I2S_MODE_TX),     \
+        .sample_rate = 48000,                                                   \
+        .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,                           \
+        .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,                           \
+        .communication_format = I2S_COMM_FORMAT_STAND_MSB,                      \
+        .dma_desc_num = 3,                                                      \
+        .dma_frame_num = 300,                                                   \
+        .use_apll = true,                                                       \
+        .tx_desc_auto_clear = true,                                             \
+        .fixed_mclk = 0                                                         \
+    },                                                                          \
+    .i2s_port = I2S_NUM_0,                                                      \
+    .use_alc = false,                                                           \
+    .volume = 0,                                                                \
+    .out_rb_size = I2S_STREAM_RINGBUFFER_SIZE,                                  \
+    .task_stack = I2S_STREAM_TASK_STACK,                                        \
+    .task_core = I2S_STREAM_TASK_CORE,                                          \
+    .task_prio = I2S_STREAM_TASK_PRIO,                                          \
+    .stack_in_ext = false,                                                      \
+    .multi_out_num = 0,                                                         \
+    .uninstall_drv = false,                                                     \
+    .need_expand = false,                                                       \
+    .expand_src_bits = I2S_BITS_PER_SAMPLE_16BIT,                               \
+}
+
 #endif
 
 /**

--- a/components/audio_stream/lib/gzip/miniz_inflate.h
+++ b/components/audio_stream/lib/gzip/miniz_inflate.h
@@ -28,8 +28,10 @@
 #include "esp_idf_version.h"
 #if (ESP_IDF_VERSION_MAJOR == 4) && (ESP_IDF_VERSION_MINOR < 3)
 #include "esp32/rom/miniz.h"
-#else
+#elif (ESP_IDF_VERSION_MAJOR < 5) && (ESP_IDF_VERSION_MINOR < 1)
 #include "rom/miniz.h"
+#else
+#include "miniz.h"
 #endif
 
 // Add the API missing in miniz of ROM code

--- a/components/esp_peripherals/lib/sdcard/sdcard.h
+++ b/components/esp_peripherals/lib/sdcard/sdcard.h
@@ -60,11 +60,13 @@ esp_err_t sdcard_mount(const char* base_path, periph_sdcard_mode_t mode);
 /**
  * @brief Unmount FAT filesystem and release resources acquired using esp_vfs_fat_sdmmc_mount
  *
+ * @param  base_path path where partition is mounted (e.g. "/sdcard")
+ *
  * @return
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_STATE if sd_card_mount hasn't been called
  */
-esp_err_t sdcard_unmount(void);
+esp_err_t sdcard_unmount(const char *base_path);
 
 /**
  * @brief remove the sdcard device GPIO interruption in Audio board

--- a/components/esp_peripherals/periph_sdcard.c
+++ b/components/esp_peripherals/periph_sdcard.c
@@ -106,7 +106,7 @@ static esp_err_t _sdcard_destroy(esp_periph_handle_t self)
     esp_err_t ret = ESP_OK;
     periph_sdcard_t *sdcard = esp_periph_get_data(self);
     if (sdcard->is_mounted) {
-        ret |= sdcard_unmount();
+        ret |= sdcard_unmount(sdcard->root);
         sdcard->is_mounted = false;
     }
     ret |= sdcard_destroy();
@@ -145,7 +145,7 @@ esp_err_t periph_sdcard_unmount(esp_periph_handle_t periph)
 {
     VALIDATE_SDCARD(periph, ESP_FAIL);
     periph_sdcard_t *sdcard = esp_periph_get_data(periph);
-    int ret = sdcard_unmount();
+    int ret = sdcard_unmount(sdcard->root);
     if (ret == ESP_OK) {
         ESP_LOGD(TAG, "UnMount SDCARD success");
         sdcard->is_mounted = false;


### PR DESCRIPTION
When building [Willow](https://github.com/toverainc/willow) with ESP-IDF 5.1, a bunch of warnings appear due to GCC 12 being much stricter and ESP-IDF deprecating some code used by ESP-ADF. We've suppressed some of those warnings with the following skdconfig changes:

```
CONFIG_ADC_SUPPRESS_DEPRECATE_WARN=y
CONFIG_GPTIMER_SUPPRESS_DEPRECATE_WARN=y
CONFIG_I2S_SUPPRESS_DEPRECATE_WARN=y
CONFIG_RMT_SUPPRESS_DEPRECATE_WARN=y
```

Afterwards, a few warnings remain. This PR, and espressif/esp-adf-libs#27 fix the remaining warnings we see.