### PR TITLE
http_stream: support HTTP authentication

### DIFF
--- a/components/audio_stream/include/http_stream.h
+++ b/components/audio_stream/include/http_stream.h
@@ -28,6 +28,7 @@
 #include "audio_error.h"
 #include "audio_element.h"
 #include "audio_common.h"
+#include "esp_http_client.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -167,6 +168,39 @@ esp_err_t http_stream_fetch_again(audio_element_handle_t el);
  *     - ESP_OK on success
  */
 esp_err_t http_stream_set_server_cert(audio_element_handle_t el, const char *cert);
+
+/**
+ * @brief       Set HTTP authentication type
+ *
+ * @param       el          The http_stream element handle
+ * @param       auth_type   HTTP autentication type, see `esp_http_client_auth_type_t`
+ *
+ * @return
+ *      - ESP_OK on success
+ */
+esp_err_t http_stream_set_auth_type(audio_element_handle_t el, esp_http_client_auth_type_t auth_type);
+
+/**
+ * @brief       Set HTTP authentication username
+ *
+ * @param       el The http_stream element handle
+ * @param       username    The HTTP authentication username
+ *
+ * @return
+ *      - ESP_OK on success
+ */
+esp_err_t http_stream_set_username(audio_element_handle_t el, const char *username);
+
+/**
+ * @brief       Set HTTP authentication password
+ *
+ * @param       el The http_stream element handle
+ * @param       username    The HTTP authentication password
+ *
+ * @return
+ *      - ESP_OK on success
+ */
+esp_err_t http_stream_set_password(audio_element_handle_t el, const char *password);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
To support authentication in [Willow Inference Server](https://github.com/toverainc/willow-inference-server) to allow people to run public, shared WIS servers, we need HTTP authentication support in http_stream. This PR adds support for it.