### PR TITLE
Add inline attribute to `ch_get_idx` (AUD-5067)

### DIFF
--- a/components/audio_recorder/include/ch_sort.h
+++ b/components/audio_recorder/include/ch_sort.h
@@ -64,7 +64,7 @@ enum _data_chan_type {
  * @return >=0: index of the given channel
  *          -1: channel not found
  */
-inline int8_t ch_get_idx(int8_t *order, size_t chan_num, uint8_t target_ch)
+__attribute__((always_inline)) inline int8_t ch_get_idx(int8_t *order, size_t chan_num, uint8_t target_ch)
 {
     for (int8_t idx = 0; idx < chan_num; idx++) {
         if (order[idx] == target_ch) {


### PR DESCRIPTION
When using [v2.6](https://github.com/espressif/esp-adf/releases/tag/v2.6) with a c++ project (ESPHome - ESP-IDF v4.4.5) I was getting this linking error.


```
Linking .pioenvs/s3-box-3-wakenet/firmware.elf
~/.platformio/packages/toolchain-xtensa-esp32s3@8.4.0+2021r2-patch5/bin/../lib/gcc/xtensa-esp32s3-elf/8.4.0/../../../../xtensa-esp32s3-elf/bin/ld: missing --end-group; added as last command line option
~/.platformio/packages/toolchain-xtensa-esp32s3@8.4.0+2021r2-patch5/bin/../lib/gcc/xtensa-esp32s3-elf/8.4.0/../../../../xtensa-esp32s3-elf/bin/ld: .pioenvs/s3-box-3-wakenet/esp-idf/audio_recorder/libaudio_recorder.a(recorder_sr.o):(.literal.feed_task+0x20): undefined reference to `ch_get_idx'
~/.platformio/packages/toolchain-xtensa-esp32s3@8.4.0+2021r2-patch5/bin/../lib/gcc/xtensa-esp32s3-elf/8.4.0/../../../../xtensa-esp32s3-elf/bin/ld: .pioenvs/s3-box-3-wakenet/esp-idf/audio_recorder/libaudio_recorder.a(recorder_sr.o): in function `ch_sort_16bit_4ch':
<project-folder>/components/audio_recorder/include/ch_sort.h:114: undefined reference to `ch_get_idx'
~/.platformio/packages/toolchain-xtensa-esp32s3@8.4.0+2021r2-patch5/bin/../lib/gcc/xtensa-esp32s3-elf/8.4.0/../../../../xtensa-esp32s3-elf/bin/ld: <project-folder>/components/audio_recorder/include/ch_sort.h:115: undefined reference to `ch_get_idx'
~/.platformio/packages/toolchain-xtensa-esp32s3@8.4.0+2021r2-patch5/bin/../lib/gcc/xtensa-esp32s3-elf/8.4.0/../../../../xtensa-esp32s3-elf/bin/ld: <project-folder>/components/audio_recorder/include/ch_sort.h:116: undefined reference to `ch_get_idx'
collect2: error: ld returned 1 exit status
*** [.pioenvs/s3-box-3-wakenet/firmware.elf] Error 1
```