### PR TITLE
audio_hal/es7210: fix es7210_set_mute (AUD-5089)

### DIFF
--- a/components/audio_hal/driver/es7210/es7210.c
+++ b/components/audio_hal/driver/es7210/es7210.c
@@ -553,8 +553,16 @@ esp_err_t es7210_adc_set_volume(int volume)
 
 esp_err_t es7210_set_mute(bool enable)
 {
-    ESP_LOGD(TAG, "ES7210 SetMute :%d", enable);
-    return ESP_OK;
+    int ret = 0;
+    if (enable) {
+        ret |= es7210_update_reg_bit(0x14, 0x03, 0x03);
+        ret |= es7210_update_reg_bit(0x15, 0x03, 0x03);
+    } else {
+        ret |= es7210_update_reg_bit(0x14, 0x03, 0x00);
+        ret |= es7210_update_reg_bit(0x15, 0x03, 0x00);
+    }
+    ESP_LOGI(TAG, "%s", enable ? "Muted" : "Unmuted");
+    return ret == 0 ? ESP_OK : ESP_FAIL;
 }
 
 void es7210_read_all(void)


### PR DESCRIPTION
The es7210_set_mute function in the es7210 driver in the audio_hal component doesn't actually do anything besides logging.