### PR TITLE
i2s_stream: do not unconditionally install I2S driver (AUD-5119)

### DIFF
--- a/components/audio_stream/i2s_stream.c
+++ b/components/audio_stream/i2s_stream.c
@@ -436,10 +436,12 @@ audio_element_handle_t i2s_stream_init(i2s_stream_cfg_t *config)
         cfg.write = _i2s_write;
     }
 
-    esp_err_t ret = i2s_driver_install(i2s->config.i2s_port, &i2s->config.i2s_config, 0, NULL);
-    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
-        audio_free(i2s);
-        return NULL;
+    if (config->install_drv) {
+        esp_err_t ret = i2s_driver_install(i2s->config.i2s_port, &i2s->config.i2s_config, 0, NULL);
+        if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+            audio_free(i2s);
+            return NULL;
+        }
     }
     i2s_stream_check_data_bits(i2s, i2s->config.i2s_config.bits_per_sample);
 

--- a/components/audio_stream/include/i2s_stream.h
+++ b/components/audio_stream/include/i2s_stream.h
@@ -50,6 +50,7 @@ typedef struct {
     int                     task_prio;          /*!< Task priority (based on freeRTOS priority) */
     bool                    stack_in_ext;       /*!< Try to allocate stack in external memory */
     int                     multi_out_num;      /*!< The number of multiple output */
+    bool                    install_drv;        /*!< whether to install the i2s driver when initializing stream*/
     bool                    uninstall_drv;      /*!< whether uninstall the i2s driver when stream destroyed*/
     bool                    need_expand;        /*!< whether to expand i2s data */
     i2s_bits_per_sample_t   expand_src_bits;    /*!< The source bits per sample when data expand */
@@ -87,6 +88,7 @@ typedef struct {
     .task_prio = I2S_STREAM_TASK_PRIO,                                          \
     .stack_in_ext = false,                                                      \
     .multi_out_num = 0,                                                         \
+    .install_drv = true,                                                        \
     .uninstall_drv = true,                                                      \
     .need_expand = false,                                                       \
     .expand_src_bits = I2S_BITS_PER_SAMPLE_16BIT,                               \
@@ -117,6 +119,7 @@ typedef struct {
     .task_prio = I2S_STREAM_TASK_PRIO,                                          \
     .stack_in_ext = false,                                                      \
     .multi_out_num = 0,                                                         \
+    .install_drv = true,                                                        \
     .uninstall_drv = false,                                                     \
     .need_expand = false,                                                       \
     .expand_src_bits = I2S_BITS_PER_SAMPLE_16BIT,                               \
@@ -145,6 +148,7 @@ typedef struct {
     .task_prio = I2S_STREAM_TASK_PRIO,                                          \
     .stack_in_ext = false,                                                      \
     .multi_out_num = 0,                                                         \
+    .install_drv = true,                                                        \
     .uninstall_drv = false,                                                     \
     .need_expand = false,                                                       \
     .expand_src_bits = I2S_BITS_PER_SAMPLE_16BIT,                               \
@@ -174,6 +178,7 @@ typedef struct {
     .task_prio = I2S_STREAM_TASK_PRIO,                                          \
     .stack_in_ext = false,                                                      \
     .multi_out_num = 0,                                                         \
+    .install_drv = true,                                                        \
     .uninstall_drv = true,                                                      \
     .need_expand = false,                                                       \
     .expand_src_bits = I2S_BITS_PER_SAMPLE_16BIT,                               \
@@ -204,6 +209,7 @@ typedef struct {
     .task_prio = I2S_STREAM_TASK_PRIO,                                          \
     .stack_in_ext = false,                                                      \
     .multi_out_num = 0,                                                         \
+    .install_drv = true,                                                        \
     .uninstall_drv = false,                                                     \
     .need_expand = false,                                                       \
     .expand_src_bits = I2S_BITS_PER_SAMPLE_16BIT,                               \
@@ -232,6 +238,7 @@ typedef struct {
     .task_prio = I2S_STREAM_TASK_PRIO,                                          \
     .stack_in_ext = false,                                                      \
     .multi_out_num = 0,                                                         \
+    .install_drv = true,                                                        \
     .uninstall_drv = false,                                                     \
     .need_expand = false,                                                       \
     .expand_src_bits = I2S_BITS_PER_SAMPLE_16BIT,                               \


### PR DESCRIPTION
Initializing an I2S stream currently unconditionally installs the I2S driver. When two I2S streams are needed, one for input and one for output, the following error occurs during initialization of the second stream:

E (21:53:24.782) i2s(legacy): i2s_check_cfg_validity(926): this i2s port is in use
E (21:53:24.791) i2s(legacy): i2s_driver_install(1582): I2S configuration is invalid

While these error messages are completely harmless, we keep getting downstream reports from people who think this is a problem. We have considered disabling logging for the legacy I2S driver, but that could lead to valid errors being suppressed.

Instead, add a new member to the i2s_stream_cfg_t struct that makes it possible to skip installing the I2S driver. It is added as true to all the macros, to not impact existing code.