### PR TITLE
recorder_sr: fix crash if WakeNet model is missing (AUD-5132)

### DIFF
--- a/components/audio_recorder/recorder_sr.c
+++ b/components/audio_recorder/recorder_sr.c
@@ -580,6 +580,10 @@ recorder_sr_handle_t recorder_sr_create(recorder_sr_cfg_t *cfg, recorder_sr_ifac
         }
     } else {
         wn_name = esp_srmodel_filter(recorder_sr->models, ESP_WN_PREFIX, recorder_sr->wn_wakeword);
+        if (wn_name == NULL) {
+            ESP_LOGE(TAG, "Please enable wakenet model and select wake word (%s) by menuconfig!", recorder_sr->wn_wakeword);
+            goto _failed;
+        }
     }
 
     cfg->afe_cfg.wakenet_model_name = wn_name;


### PR DESCRIPTION
When the SR recorder is created with specific wake word, and that wake word is missing from the model partition, the following crash occurs:

E (5703) AFE_SR: ERROR: Please select wake words!

Guru Meditation Error: Core  0 panic'ed (LoadProhibited). Exception was unhandled.

Core  0 register dump:
PC      : 0x420703ab  PS      : 0x00060030  A0      : 0x82015d72  A1      : 0x3fcb9e80
A2      : 0x3c26720c  A3      : 0x3fcb9ef0  A4      : 0x00000000  A5      : 0x00000000
A6      : 0x00000001  A7      : 0x3c266f9c  A8      : 0x8207034c  A9      : 0x3fcb9e20
A10     : 0x00000000  A11     : 0x3c1c6e0c  A12     : 0x3c1c7680  A13     : 0x00001647
A14     : 0x3c1c6e0c  A15     : 0x447fc000  SAR     : 0x00000004  EXCCAUSE: 0x0000001c
EXCVADDR: 0x00000008  LBEG    : 0x400556d5  LEND    : 0x400556e5  LCOUNT  : 0xfffffffe

Backtrace: 0x420703a8:0x3fcb9e80 0x42015d6f:0x3fcb9eb0 0x4200cb32:0x3fcb9ef0 0x4200ce2b:0x3fcba0e0 0x4200b785:0x3fcba1b0 0x42170f06:0x3fcba260

Fix this by adding a NULL check.

Fixes: 5fab75d9cf18 ("audio_recorder: restore ability to select wake word")