### PR TITLE
fix es8311 codec slow fade in (AUD-5160)

### DIFF
--- a/components/esp_codec_dev/device/es8311/es8311.c
+++ b/components/esp_codec_dev/device/es8311/es8311.c
@@ -323,7 +323,7 @@ static int es8311_start(audio_codec_es8311_t *codec)
     ret |= es8311_write_reg(codec, ES8311_SYSTEM_REG14, regv);
     ret |= es8311_write_reg(codec, ES8311_SYSTEM_REG0D, 0x01);
     ret |= es8311_write_reg(codec, ES8311_ADC_REG15, 0x40);
-    ret |= es8311_write_reg(codec, ES8311_DAC_REG37, 0x48);
+    ret |= es8311_write_reg(codec, ES8311_DAC_REG37, 0x08);
     ret |= es8311_write_reg(codec, ES8311_GP_REG45, 0x00);
     return ret;
 }


### PR DESCRIPTION
When playing audio on speaker on esp32-s3-korvo-1 board, the first time it plays fine, any consecutive replay has very slow fade in - the recording (~5s) is not audible until the very end. This change fixes it.