### PR TITLE
Add support for safe I2C actions from outside this library (AUD-5257)

### DIFF
--- a/components/esp_peripherals/driver/i2c_bus/i2c_bus.c
+++ b/components/esp_peripherals/driver/i2c_bus/i2c_bus.c
@@ -216,3 +216,17 @@ esp_err_t i2c_bus_probe_addr(i2c_bus_handle_t bus, uint8_t addr)
     /* Get probe result if ESP_OK equals to ret_val */
     return ret_val;
 }
+
+esp_err_t i2c_bus_run_cb(i2c_bus_handle_t bus, i2c_run_cb_t cb, void * arg)
+{
+    I2C_BUS_CHECK(bus != NULL, "Handle error", ESP_FAIL);
+    I2C_BUS_CHECK(cb != NULL, "Invalid callback", ESP_FAIL);
+
+    i2c_bus_t *i2c_bus = (i2c_bus_t *) bus;
+    mutex_lock(i2c_bus->bus_lock);
+    (*cb)(i2c_bus->i2c_port, arg);
+    mutex_unlock(i2c_bus->bus_lock);
+
+    return ESP_OK;
+}
+

--- a/components/esp_peripherals/driver/i2c_bus/i2c_bus.h
+++ b/components/esp_peripherals/driver/i2c_bus/i2c_bus.h
@@ -31,6 +31,7 @@ extern "C" {
 #endif
 
 typedef void *i2c_bus_handle_t;
+typedef void (*i2c_run_cb_t)(i2c_port_t port, void * arg);
 
 /**
  * @brief Create and init I2C bus and return a I2C bus handle
@@ -124,6 +125,20 @@ esp_err_t i2c_bus_cmd_begin(i2c_bus_handle_t bus, i2c_cmd_handle_t cmd, portBASE
  *     - ESP_FAIL Fail
  */
 esp_err_t i2c_bus_probe_addr(i2c_bus_handle_t bus, uint8_t addr);
+
+
+/**
+ * @brief Lock the I2C bus while executing the given callback
+ *
+ * @param bus            I2C bus handle
+ * @param cb             The callback to execute
+ * @param arg            The argument for the callback
+ *
+ * @return
+ *     - ESP_OK Done calling callback function
+ *     - ESP_FAIL Fail
+ */
+esp_err_t i2c_bus_run_cb(i2c_bus_handle_t bus, i2c_run_cb_t cb, void * arg);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Currently, it's not possible to have esp-adf with other code base using I2C.

This is because another code base will call esp-idf's `i2c_driver_install` on some `i2c_port` and so will esp_adf via the `esp_peripherals/driver/i2c_bus` component.

I2C bus does check if **its own** driver is already installed with the same configuration and skip it in that case but it doesn't check if some other code installed it. In that case, it'll error out and any code depending on this i2c_bus will fail later one, breaking the application. 

All I2C related stuff is private/static in `i2c_bus.c` so it's not possible for the other code to figure out what is the state of the i2c_port without potentially breaking it when installing the driver. `i2c_driver_install` will error out if it's already installed so the other code will also error out, preventing any later I2C work to be done.

If the other code is modified to skip driver installation, then it'll likely break since there is no way to access the mutex protecting the bus from outside the `i2c_bus.c` file nor is there a way to get the `i2c_port_t` instance.

This patch allows to run I2C related code from outside this component *without* exposing the inner working of this component. It's done by running a user provided callback function with the mutex taken and the right `i2c_port_t` instance for the bus. 

I think it's the cleanest solution that can allow heterogeneous code to work together (for example ESPHome).

