### PR TITLE
fix: added missing lock.h (AUD-5488)

### DIFF
--- a/components/bluetooth_service/a2dp_stream.c
+++ b/components/bluetooth_service/a2dp_stream.c
@@ -24,6 +24,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <sys/lock.h>
 #include <inttypes.h>
 #include "nvs.h"
 #include "nvs_flash.h"


### PR DESCRIPTION
We encoutered some issue when trying to build `a2dp_stream.c` on Linux for testing.

The file a2dp_stream.c uses a `_lock_t` but never imports the actual header for it.
It is probably included conditionally somewhere else when we build for the device.