### PR TITLE
Github issue #1207 #1199 fixed (AUD-5549)

### DIFF
--- a/components/esp_actions/nvs_action.c
+++ b/components/esp_actions/nvs_action.c
@@ -213,8 +213,8 @@ esp_err_t nvs_action_get_stats(void *instance, action_arg_t *arg, action_result_
     AUDIO_MEM_CHECK(TAG, arg, return ESP_FAIL);
     AUDIO_MEM_CHECK(TAG, result, return ESP_FAIL);
 
-    result->data = audio_calloc(1, sizeof(action_result_t));
-    result->len = sizeof(action_result_t);
+    result->data = audio_calloc(1, sizeof(nvs_stats_t));
+    result->len = sizeof(nvs_stats_t);
 
     return nvs_get_stats(arg->data, result->data);
 }

--- a/components/esp_peripherals/lib/sdcard/sdcard.c
+++ b/components/esp_peripherals/lib/sdcard/sdcard.c
@@ -163,14 +163,17 @@ esp_err_t sdcard_mount(const char *base_path, periph_sdcard_mode_t mode)
 
 }
 
-esp_err_t sdcard_unmount(const char *base_path)
+esp_err_t sdcard_unmount(const char *base_path, periph_sdcard_mode_t mode)
 {
 #if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0))
     esp_err_t ret = esp_vfs_fat_sdcard_unmount(base_path, card);
 #else
     esp_err_t ret = esp_vfs_fat_sdmmc_unmount();
 #endif
-
+    if(mode == SD_MODE_SPI) {
+        sdmmc_host_t host = SDSPI_HOST_DEFAULT();
+        spi_bus_free(host.slot);
+    }
     if (ret == ESP_ERR_INVALID_STATE) {
         ESP_LOGE(TAG, "File system not mounted");
     }

--- a/components/esp_peripherals/lib/sdcard/sdcard.h
+++ b/components/esp_peripherals/lib/sdcard/sdcard.h
@@ -66,7 +66,7 @@ esp_err_t sdcard_mount(const char* base_path, periph_sdcard_mode_t mode);
  *      - ESP_OK on success
  *      - ESP_ERR_INVALID_STATE if sd_card_mount hasn't been called
  */
-esp_err_t sdcard_unmount(const char *base_path);
+esp_err_t sdcard_unmount(const char *base_path, periph_sdcard_mode_t mode);
 
 /**
  * @brief remove the sdcard device GPIO interruption in Audio board

--- a/components/esp_peripherals/periph_sdcard.c
+++ b/components/esp_peripherals/periph_sdcard.c
@@ -106,7 +106,7 @@ static esp_err_t _sdcard_destroy(esp_periph_handle_t self)
     esp_err_t ret = ESP_OK;
     periph_sdcard_t *sdcard = esp_periph_get_data(self);
     if (sdcard->is_mounted) {
-        ret |= sdcard_unmount(sdcard->root);
+        ret |= sdcard_unmount(sdcard->root, sdcard->sd_mode);
         sdcard->is_mounted = false;
     }
     ret |= sdcard_destroy();
@@ -145,7 +145,7 @@ esp_err_t periph_sdcard_unmount(esp_periph_handle_t periph)
 {
     VALIDATE_SDCARD(periph, ESP_FAIL);
     periph_sdcard_t *sdcard = esp_periph_get_data(periph);
-    int ret = sdcard_unmount(sdcard->root);
+    int ret = sdcard_unmount(sdcard->root, sdcard->sd_mode);
     if (ret == ESP_OK) {
         ESP_LOGD(TAG, "UnMount SDCARD success");
         sdcard->is_mounted = false;


### PR DESCRIPTION
Resolved the issue of SPI bus not releasing after SD card unmount; 
fixed the memory allocation size issue in the nvs_action_get_stats function for result->data.