### PR TITLE
Correct all instances of "destory" to "destroy" (AUD-5681)

### DIFF
--- a/components/bluetooth_service/a2dp_stream.c
+++ b/components/bluetooth_service/a2dp_stream.c
@@ -66,7 +66,7 @@ typedef struct {
 typedef struct {
     enum {
         A2DP_TYPE_SINK ,
-        A2DP_TYPE_DESTORY,
+        A2DP_TYPE_DESTROY,
     } type;
     void *data;
     size_t size;
@@ -96,7 +96,7 @@ static void audio_a2dp_stream_thread(void *pvParameters)
                     audio_free(recv_msg.data);
                     recv_msg.data = NULL;
                 break;
-            case A2DP_TYPE_DESTORY:
+            case A2DP_TYPE_DESTROY:
                 _aadp_task_run = false;
                 break;
             default:
@@ -267,15 +267,15 @@ static int32_t bt_a2d_source_data_cb(uint8_t *data, int32_t len)
     return 0;
 }
 
-static esp_err_t a2dp_sink_destory(audio_element_handle_t self)
+static esp_err_t a2dp_sink_destroy(audio_element_handle_t self)
 {
-    ESP_LOGI(TAG, "a2dp_sink_destory");
+    ESP_LOGI(TAG, "a2dp_sink_destroy");
 
-    a2dp_data_t destory_msg = {
-        .type = A2DP_TYPE_DESTORY,
+    a2dp_data_t destroy_msg = {
+        .type = A2DP_TYPE_DESTROY,
     };
-    if ( xQueueSend( s_aadp_handler.a2dp_queue, &destory_msg, 0 )  != pdPASS ) {
-        ESP_LOGE(TAG, "Destory audio_a2dp_stream_thread failed");
+    if ( xQueueSend( s_aadp_handler.a2dp_queue, &destroy_msg, 0 )  != pdPASS ) {
+        ESP_LOGE(TAG, "Destroy audio_a2dp_stream_thread failed");
         return ESP_FAIL;
     }
     s_aadp_handler.sink_stream = NULL;
@@ -283,7 +283,7 @@ static esp_err_t a2dp_sink_destory(audio_element_handle_t self)
     return ESP_OK;
 }
 
-static esp_err_t a2dp_source_destory(audio_element_handle_t self)
+static esp_err_t a2dp_source_destroy(audio_element_handle_t self)
 {
     s_aadp_handler.source_stream = NULL;
     memset(&s_aadp_handler.user_callback, 0, sizeof(a2dp_stream_user_callback_t));
@@ -322,7 +322,7 @@ audio_element_handle_t a2dp_stream_init(a2dp_stream_config_t *config)
     if (config->type == AUDIO_STREAM_READER) {
         // A2DP sink
         s_aadp_handler.stream_type = AUDIO_STREAM_READER;
-        cfg.destroy = a2dp_sink_destory;
+        cfg.destroy = a2dp_sink_destroy;
         el = s_aadp_handler.sink_stream = audio_element_init(&cfg);
 
         esp_a2d_sink_register_data_callback(bt_a2d_sink_data_cb);
@@ -331,7 +331,7 @@ audio_element_handle_t a2dp_stream_init(a2dp_stream_config_t *config)
     } else {
         // A2DP source
         s_aadp_handler.stream_type = AUDIO_STREAM_WRITER;
-        cfg.destroy = a2dp_source_destory;
+        cfg.destroy = a2dp_source_destroy;
         el = s_aadp_handler.source_stream = audio_element_init(&cfg);
 
         esp_a2d_register_callback(bt_a2d_source_cb);

--- a/components/bluetooth_service/test/test_bluetooth_service.c
+++ b/components/bluetooth_service/test/test_bluetooth_service.c
@@ -87,7 +87,7 @@ TEST_CASE("Initialize a2dp sink, create bluetooth stream and destroy stream late
     TEST_ASSERT_FALSE(esp_periph_start(set, bt_periph));
     vTaskDelay(100 / portTICK_PERIOD_MS);
 
-    ESP_LOGI(TAG, "Destory stream");
+    ESP_LOGI(TAG, "Destroy stream");
     TEST_ASSERT_EQUAL(ESP_OK, esp_periph_set_stop_all(set));
     TEST_ASSERT_EQUAL(ESP_OK, audio_element_stop(bt_stream_reader));
     TEST_ASSERT_EQUAL(ESP_OK, audio_element_deinit(bt_stream_reader));
@@ -135,7 +135,7 @@ TEST_CASE("Initialize a2dp source, create bluetooth stream and destroy stream la
     ESP_LOGI(TAG, "Start bt peripheral");
     TEST_ASSERT_FALSE(esp_periph_start(set, bt_periph));
     vTaskDelay(100 / portTICK_PERIOD_MS);
-    ESP_LOGI(TAG, "Destory stream");
+    ESP_LOGI(TAG, "Destroy stream");
     TEST_ASSERT_EQUAL(ESP_OK, esp_periph_set_stop_all(set));
     TEST_ASSERT_EQUAL(ESP_OK, audio_element_stop(bt_stream_writer));
     TEST_ASSERT_EQUAL(ESP_OK, audio_element_deinit(bt_stream_writer));
@@ -181,7 +181,7 @@ TEST_CASE("Initialize a2dp sink, test discovery and cancel discovery", "[bluetoo
     TEST_ASSERT_EQUAL(ESP_OK, periph_bluetooth_cancel_discover(bt_periph));
     audio_element_run(bt_stream_reader);
 
-    ESP_LOGI(TAG, "Destory stream");
+    ESP_LOGI(TAG, "Destroy stream");
     TEST_ASSERT_EQUAL(ESP_OK, esp_periph_set_stop_all(set));
     TEST_ASSERT_EQUAL(ESP_OK, audio_element_stop(bt_stream_reader));
     TEST_ASSERT_EQUAL(ESP_OK, audio_element_deinit(bt_stream_reader));

--- a/components/clouds/dueros/lightduer/include/lightduer_http_client_ops.h
+++ b/components/clouds/dueros/lightduer/include/lightduer_http_client_ops.h
@@ -28,7 +28,7 @@ extern "C" {
 
 extern duer_http_client_t *duer_create_http_client(void);
 
-extern void duer_destory_http_client(duer_http_client_t *client);
+extern void duer_destroy_http_client(duer_http_client_t *client);
 
 #ifdef __cplusplus
 }

--- a/components/clouds/dueros/lightduer/include/lightduer_ota_installer.h
+++ b/components/clouds/dueros/lightduer/include/lightduer_ota_installer.h
@@ -133,7 +133,7 @@ extern void *duer_ota_installer_get_custom_data(duer_ota_installer_t const *inst
 extern duer_ota_installer_t *duer_ota_installer_create_installer(char const *name);
 
 /*
- * Destory a OTA installer
+ * Destroy a OTA installer
  *
  * @param installer: OTA installer
  *

--- a/components/esp_peripherals/lib/sdcard/sdcard.h
+++ b/components/esp_peripherals/lib/sdcard/sdcard.h
@@ -75,7 +75,7 @@ esp_err_t sdcard_unmount(const char *base_path, periph_sdcard_mode_t mode);
  *
  * @return
  *      - ESP_OK on success
- *      - ESP_FAIL destory sdcard gpio handle failed
+ *      - ESP_FAIL destroy sdcard gpio handle failed
  */
 esp_err_t sdcard_destroy(void);
 

--- a/components/esp_peripherals/periph_gpio_isr.c
+++ b/components/esp_peripherals/periph_gpio_isr.c
@@ -72,7 +72,7 @@ static esp_err_t _gpio_isr_run(esp_periph_handle_t self, audio_event_iface_msg_t
     return ESP_FAIL;
 }
 
-static esp_err_t _gpio_isr_destory(esp_periph_handle_t self)
+static esp_err_t _gpio_isr_destroy(esp_periph_handle_t self)
 {
     esp_err_t ret = ESP_OK;
     gpio_isr_node_t *tmp, *item;
@@ -151,7 +151,7 @@ esp_periph_handle_t periph_gpio_isr_init(periph_gpio_isr_cfg_t *isr_config)
     }
 
     esp_periph_set_data(periph, &gpio_isr_info_list);
-    esp_periph_set_function(periph, _gpio_isr_init, _gpio_isr_run, _gpio_isr_destory);
+    esp_periph_set_function(periph, _gpio_isr_init, _gpio_isr_run, _gpio_isr_destroy);
     g_handle = periph;
     return periph;
 }

--- a/examples/advanced_examples/audio_mixer_tone/README.md
+++ b/examples/advanced_examples/audio_mixer_tone/README.md
@@ -29,7 +29,7 @@ Refer to the table below for the supported commands:
 |03| pmixer| Play a single audio channel. Multiple channels can be played simultaneously using different slots to achieve mixing effects |cli_play_mixer|
 |04| smixer| Stop playback initiated by `pmixer` |cli_replay_mixer|
 |05| rpmixer| Replay the audio of the `pmixer`. Ensure that the pmixer is in a stopped or completed state before replay |cli_stop_mixer|
-|06| dmixer| Destroy the PMixer, which allows the released slots to be reused by other channels after destruction |cli_destory_mixer|
+|06| dmixer| Destroy the PMixer, which allows the released slots to be reused by other channels after destruction |cli_destroy_mixer|
 |07| gmixer| Set the gain value for the corresponding slot |cli_mixer_gain_set|
 |08| record| Starting or stopping recording while playing or pausing can simulate a karaoke scene |recorder_fn|
 
@@ -385,7 +385,7 @@ I (210661) MIXER_PIPE: Mixer manager REC CMD:8,dat:14 src:0x3c16c014, Mixer:0x3c
 ```c
 esp32> dmixer 0
 I (230031) MIXER_PIPE: Waiting the task destroied...
-I (230031) MIXER_PIPE: mixer pipeline destory
+I (230031) MIXER_PIPE: mixer pipeline destroy
 W (230041) AUDIO_ELEMENT: [mixing_in] Element has not create when AUDIO_ELEMENT_TERMINATE
 W (230051) AUDIO_ELEMENT: [mixing_dec] Element has not create when AUDIO_ELEMENT_TERMINATE
 I (230061) CODEC_ELEMENT_HELPER: The element is 0x3c1579a0. The reserve data 2 is 0x0.

--- a/examples/advanced_examples/audio_mixer_tone/README_CN.md
+++ b/examples/advanced_examples/audio_mixer_tone/README_CN.md
@@ -29,7 +29,7 @@
    |03| pmixer| 播放单一音频通道。可以同时使用不同的槽位播放多个通道，做到混音的效果|cli_play_mixer|
    |04| smixer| 停止由 pmixer启动的播放 |cli_replay_mixer|
    |05| rpmixer| 重新播放pmixer的音频。确保pmixer处于停止或完成的状态后再重新播放|cli_stop_mixer|
-   |06| dmixer| 销毁pmixer，销毁后可以让被释放的槽位被其他通道重新使用|cli_destory_mixer|
+   |06| dmixer| 销毁pmixer，销毁后可以让被释放的槽位被其他通道重新使用|cli_destroy_mixer|
    |07| gmixer| 设置相应槽位银牌的增益值|cli_mixer_gain_set|
    |08| record| 开始录音或者停止录音并同时播放出来或暂停， 可以模拟卡拉ok场景|recorder_fn|
 ## 环境配置
@@ -385,7 +385,7 @@ I (210661) MIXER_PIPE: Mixer manager REC CMD:8,dat:14 src:0x3c16c014, Mixer:0x3c
 ```c
 esp32> dmixer 0
 I (230031) MIXER_PIPE: Waiting the task destroied...
-I (230031) MIXER_PIPE: mixer pipeline destory
+I (230031) MIXER_PIPE: mixer pipeline destroy
 W (230041) AUDIO_ELEMENT: [mixing_in] Element has not create when AUDIO_ELEMENT_TERMINATE
 W (230051) AUDIO_ELEMENT: [mixing_dec] Element has not create when AUDIO_ELEMENT_TERMINATE
 I (230061) CODEC_ELEMENT_HELPER: The element is 0x3c1579a0. The reserve data 2 is 0x0.

--- a/examples/advanced_examples/audio_mixer_tone/components/audio_mixer_pipeline/audio_mixer_pipeline.c
+++ b/examples/advanced_examples/audio_mixer_tone/components/audio_mixer_pipeline/audio_mixer_pipeline.c
@@ -177,7 +177,7 @@ void mixer_manager(void *para)
     xEventGroupSetBits(mixer_pipe->evt_sync, MP_DESTROYED);
     audio_mixer_set_read_cb(mixer_pipe->mixer, mixer_pipe->idx, NULL, NULL);
     _mixer_pipeline_event_dispatcher(MIXER_PIP_EVENT_DESTROY, mixer_pipe, mixer_pipe->idx);
-    ESP_LOGI(TAG, "mixer pipeline destory");
+    ESP_LOGI(TAG, "mixer pipeline destroy");
     vTaskDelete(NULL);
 }
 

--- a/examples/advanced_examples/audio_mixer_tone/main/audio_mixer_example.c
+++ b/examples/advanced_examples/audio_mixer_tone/main/audio_mixer_example.c
@@ -144,7 +144,7 @@ static esp_err_t cli_stop_mixer(esp_periph_handle_t periph, int argc, char *argv
     return ESP_OK;
 }
 
-static esp_err_t cli_destory_mixer(esp_periph_handle_t periph, int argc, char *argv[])
+static esp_err_t cli_destroy_mixer(esp_periph_handle_t periph, int argc, char *argv[])
 {
     if (argc < 1) {
         ESP_LOGE(TAG, "Usage: stop_mixer paramsters");
@@ -331,7 +331,7 @@ const periph_console_cmd_t cli_cmd[] = {
     "    example: pmixer /sdcard/test.mp3 1\n             pmixer flash://tone/1_wozai.mp3 2\n             pmixer https://dl.espressif.com/dl/audio/ff-16b-2c-44100hz.mp3 3", .func = cli_play_mixer },
     { .cmd = "rpmixer", .id = 11, .help = "Replays the audio from pmixer. Ensures that pmixer is in a stopped or finished state before replaying.\n    example: rpmixer 1\n", .func = cli_replay_mixer },
     { .cmd = "smixer",  .id = 12, .help = "Stop pmixer, temporarily halting audio playback.\n    example: smixer 1\n", .func = cli_stop_mixer },
-    { .cmd = "dmixer",  .id = 13, .help = "Destroys pmixer, allowing the freed slots to be used by other channels after destruction.\n    example: dmixer 1\n", .func = cli_destory_mixer },
+    { .cmd = "dmixer",  .id = 13, .help = "Destroys pmixer, allowing the freed slots to be used by other channels after destruction.\n    example: dmixer 1\n", .func = cli_destroy_mixer },
     { .cmd = "gmixer",  .id = 14, .help = "Set the gain value for the output of the corresponding slot.\n    example: gmixer 1 -3\\n", .func = cli_mixer_gain_set },
 
     { .cmd = "setvol",  .id = 15, .help = "Set volume", .func = cli_set_vol },

--- a/examples/korvo_du1906/components/bds_light/include/bds_client_command.h
+++ b/examples/korvo_du1906/components/bds_light/include/bds_client_command.h
@@ -83,7 +83,7 @@ typedef struct {
 bdsc_cmd_data_t *bdsc_cmd_data_create(int32_t flag, uint16_t buffer_length, uint8_t *buffer, char *sn);
 
 /**
- * @brief      Destory bdsc cmd data
+ * @brief      Destroy bdsc cmd data
  *
  * @param[in]  data           bdsc_cmd_data_t handle
  *

--- a/examples/korvo_du1906/components/bds_light/include/bds_client_params.h
+++ b/examples/korvo_du1906/components/bds_light/include/bds_client_params.h
@@ -204,7 +204,7 @@ bdsc_engine_params_t *bdsc_engine_params_create(char *sn, uint32_t pid, char *ho
         char *cuid, char *app, LAUNCH_MODE_T launch_mode, uint16_t pam_len, char *pam);
 
 /**
- * @brief      destory bdsc engine params
+ * @brief      destroy bdsc engine params
  *
  * @param[in]  params               params
  *

--- a/examples/korvo_du1906/components/bdsc_engine/include/bdsc_http.h
+++ b/examples/korvo_du1906/components/bdsc_engine/include/bdsc_http.h
@@ -64,7 +64,7 @@ int bdsc_send_https_post_sync(char *server, int port,
  */
 int bdsc_send_http_get_with_cb(esp_http_client_handle_t client, char *url, uint64_t pos);
 
-esp_err_t bdsc_http_cb_destory();
+esp_err_t bdsc_http_cb_destroy();
 #ifdef __cplusplus
 }
 #endif

--- a/examples/korvo_du1906/patches/a2dp_stream_du1906.patch
+++ b/examples/korvo_du1906/patches/a2dp_stream_du1906.patch
@@ -37,13 +37,13 @@ index 1d5c1905..1ddc0346 100644
                      audio_free(recv_msg.data);
                      recv_msg.data = NULL;
 -                break;
--            case A2DP_TYPE_DESTORY:
+-            case A2DP_TYPE_DESTROY:
 -                _aadp_task_run = false;
 -                break;
 -            default:
 -                break;
 +                    break;
-+                case A2DP_TYPE_DESTORY:
++                case A2DP_TYPE_DESTROY:
 +                    _aadp_task_run = false;
 +                    break;
 +                default:


### PR DESCRIPTION
## Description
Simple correction of a common typo in the codebase

## Testing
Tested I could still build pipeline_sdcard_mp3_control

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
