### PR TITLE
esp_codec_dev: Fix volume setting for ES8374 (AUD-5742)

### DIFF
--- a/components/esp_codec_dev/device/es8374/es8374.c
+++ b/components/esp_codec_dev/device/es8374/es8374.c
@@ -391,7 +391,7 @@ static int es8374_config_adc_input(audio_codec_es8374_t *codec, es_adc_input_t i
 
 static int es8374_set_adc_dac_volume(audio_codec_es8374_t *codec, esp_codec_dec_work_mode_t mode, float db_value)
 {
-    int reg = esp_codec_dev_vol_calc_db(&vol_range, db_value);
+    int reg = esp_codec_dev_vol_calc_reg(&vol_range, db_value);
     int ret = ESP_CODEC_DEV_OK;
     if (mode & ESP_CODEC_DEV_WORK_MODE_ADC) {
         ret = es8374_write_reg(codec, 0x25, (uint8_t) reg);


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
Fixes output volume setting for ES8374 codec in the `esp_codec_dev` component. Bug was introduced when the component was created. The problem is the db_value, mapped from a volume integer, needs to be converted to a register value, however the incorrect method `esp_codec_dev_vol_calc_db` is used. It should be `esp_codec_dev_vol_calc_reg`.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
