### PR TITLE
Fix memory leak caused by reopening algorithmic stream (AUD-6046)

### DIFF
--- a/components/audio_stream/algorithm_stream.c
+++ b/components/audio_stream/algorithm_stream.c
@@ -213,6 +213,12 @@ static esp_err_t _algo_open(audio_element_handle_t self)
         afe_config.voice_communication_agc_gain = algo->agc_gain;
     }
 
+    if (algo->afe_data) {
+        algo->afe_handle->destroy(algo->afe_data);
+        algo->afe_data = NULL;
+    }
+
+
     algo->afe_data = algo->afe_handle->create_from_config(&afe_config);
     algo->afe_fetch_run = true;
 


### PR DESCRIPTION
Fix memory leak in algorithm_stream

Fixes #1360 

### Problem Description
When pausing and resuming a pipeline containing algorithm_stream, AFE data is not properly cleaned up, causing memory leaks.

### Fix
Added cleanup of existing AFE data in `_algo_open` function before creating new instances.

### Verification
- A minimal reproduction demo is available at: https://github.com/gizwits/algorithm_stream_demo
- Memory usage remains stable after applying the fix when performing multiple pause/resume cycles

### Modified Files
- components/audio_stream/algorithm_stream.c