### PR TITLE
audio_pipeline : Fix single element error (AUD-6121)

### DIFF
--- a/components/audio_pipeline/audio_pipeline.c
+++ b/components/audio_pipeline/audio_pipeline.c
@@ -462,6 +462,9 @@ static esp_err_t _pipeline_rb_linked(audio_pipeline_handle_t pipeline, audio_ele
 {
     static ringbuf_handle_t rb;
     ringbuf_item_t *rb_item;
+    if (first) {
+        rb = NULL;
+    }
     if (last) {
         audio_element_set_input_ringbuf(el, rb);
     } else {


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

An attempt has been made to fix the ringbuffer allocation errors that may be caused by creating multiple pipelines, some of which contain only a single element.



## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->
GH - https://github.com/espressif/esp-adf/issues/1341


