### PR TITLE
Fix tone partition index and update the

### DIFF
--- a/components/audio_stream/tone_stream.c
+++ b/components/audio_stream/tone_stream.c
@@ -34,6 +34,8 @@
 #include "tone_stream.h"
 #include <inttypes.h>
 
+#define DEFAULT_TONE_NUM 4
+
 static const char *TAG = "TONE_STREAM";
 
 /**
@@ -64,7 +66,7 @@ static esp_err_t _tone_open(audio_element_handle_t self)
 
     flash_url += strlen("flash://tone/");
     char *temp = strchr(flash_url, '_');
-    char find_num[2] = { 0 };
+    char find_num[DEFAULT_TONE_NUM] = {0};
     int file_index = 0;
     if (temp != NULL) {
         strncpy(find_num, flash_url, temp - flash_url);

--- a/components/tone_partition/tone_partition.c
+++ b/components/tone_partition/tone_partition.c
@@ -92,7 +92,7 @@ esp_err_t tone_partition_get_file_info(tone_partition_handle_t handle, uint16_t 
     AUDIO_NULL_CHECK(TAG, handle, return ESP_FAIL);
     AUDIO_NULL_CHECK(TAG, info, return ESP_FAIL);
 
-    if (handle->header.total_num < index) {
+    if (handle->header.total_num <= index) {
         ESP_LOGE(TAG, "Wanted index out of range index[%d]", index);
         return ESP_FAIL;
     }


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
Change the index check to include the case where `index == total_num`. Update `find_num` array size to `DEFAULT_TONE_NUM` for longer tone index.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related
#1391 

## Testing
Tested on ESP32-S3-Korvo-2 development board using pipline_flash_tone example. When  index == total_num, the error was handled properly.


---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
