### PR TITLE
Copy fix for ESP32-C3-Lyra-V2 from SPIFFS sample

### DIFF
--- a/examples/player/pipeline_http_mp3/main/play_http_mp3_example.c
+++ b/examples/player/pipeline_http_mp3/main/play_http_mp3_example.c
@@ -70,7 +70,11 @@ void app_main(void)
     http_stream_reader = http_stream_init(&http_cfg);
 
     ESP_LOGI(TAG, "[2.2] Create i2s stream to write data to codec chip");
+#if defined CONFIG_ESP32_C3_LYRA_V2_BOARD
+    i2s_stream_cfg_t i2s_cfg = I2S_STREAM_PDM_TX_CFG_DEFAULT();
+#else
     i2s_stream_cfg_t i2s_cfg = I2S_STREAM_CFG_DEFAULT();
+#endif
     i2s_cfg.type = AUDIO_STREAM_WRITER;
     i2s_stream_writer = i2s_stream_init(&i2s_cfg);
 


### PR DESCRIPTION
## Description

Sound output on the ESP32-C3-Lyra sounds terrible in this sample, while it seems to work fine in the `pipeline_spiffs_mp3`.  Copy fix from that sample.

## Testing

Verified on an ESP32-C3-Lyra V2 board.  Music sounds much better.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [*] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [*] Git history is clean — commits are squashed to the minimum necessary.