### PR TITLE
bugfix(esp_codec_dev): Clear pending disable flags when re-enabling RX/TX (AUD-6744)

### DIFF
--- a/components/esp_codec_dev/platform/audio_codec_data_i2s.c
+++ b/components/esp_codec_dev/platform/audio_codec_data_i2s.c
@@ -389,6 +389,15 @@ static int _i2s_data_enable(const audio_codec_data_if_t *h, esp_codec_dev_type_t
                     ret = _i2s_drv_enable(i2s_data, false, enable);
                     i2s_data->in_disable_pending = false;
                 }
+            } else {
+                if (playback == true && i2s_data->out_disable_pending) {
+                    ESP_LOGI(TAG, "Clearing out_disable_pending flag when enabling out channel");
+                    i2s_data->out_disable_pending = false;
+                }
+                if (playback == false && i2s_data->in_disable_pending) {
+                    ESP_LOGI(TAG, "Clearing in_disable_pending flag when enabling in channel");
+                    i2s_data->in_disable_pending = false;
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

This PR fixes an inconsistency in the I2S codec driver state handling. When disabling one channel (IN/RX or OUT/TX) while the opposite channel is still running, a `*_disable_pending` flag is set. However, if the same channel is later re-enabled, the pending flag was not cleared, leaving the internal state inconsistent (the channel is active but still marked as "pending disable").

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
