### PR TITLE
Allow configuring http_stream buffer_size and buffer_size_tx (AUD-7208)

### DIFF
--- a/components/audio_stream/http_stream.c
+++ b/components/audio_stream/http_stream.c
@@ -102,6 +102,9 @@ typedef struct http_stream {
     bool                            is_last_range;
     const char                      *user_agent;
     int                             buffer_size;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 1, 0)
+    int                             buffer_size_tx;
+#endif
 } http_stream_t;
 
 static esp_err_t http_stream_auto_connect_next_track(audio_element_handle_t el);
@@ -573,7 +576,7 @@ _stream_open_begin:
             .timeout_ms = 30 * 1000,
             .buffer_size = http->buffer_size,
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 1, 0)
-            .buffer_size_tx = 1024,
+            .buffer_size_tx = http->buffer_size_tx,
 #endif
             .cert_pem = http->cert_pem,
 #if  (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 3, 0)) && defined CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
@@ -907,6 +910,9 @@ audio_element_handle_t http_stream_init(http_stream_cfg_t *config)
     http->user_agent = config->user_agent;
     http->url_index = config->url_index;
     http->buffer_size = config->buffer_size;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 1, 0)
+    http->buffer_size_tx = config->buffer_size_tx;
+#endif
 
     if (config->crt_bundle_attach) {
 #if  (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 3, 0))

--- a/components/audio_stream/include/http_stream.h
+++ b/components/audio_stream/include/http_stream.h
@@ -97,14 +97,38 @@ typedef struct {
     const char                  *user_agent;            /*!< The User Agent string to send with HTTP requests */
     int                         url_index;              /*!< The url index to be played in playlist */
     int                         buffer_size;            /*!< HTTP receive buffer size */
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 1, 0)
+    int                         buffer_size_tx;         /*!< HTTP send buffer size */
+#endif
 } http_stream_cfg_t;
 
 #define HTTP_STREAM_BUFFER_SIZE         (2048)
+#define HTTP_STREAM_BUFFER_SIZE_TX      (1024)
 #define HTTP_STREAM_TASK_STACK          (6 * 1024)
 #define HTTP_STREAM_TASK_CORE           (0)
 #define HTTP_STREAM_TASK_PRIO           (4)
 #define HTTP_STREAM_RINGBUFFER_SIZE     (20 * 1024)
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 1, 0)
+#define HTTP_STREAM_CFG_DEFAULT() {              \
+    .type = AUDIO_STREAM_READER,                 \
+    .out_rb_size = HTTP_STREAM_RINGBUFFER_SIZE,  \
+    .task_stack = HTTP_STREAM_TASK_STACK,        \
+    .task_core = HTTP_STREAM_TASK_CORE,          \
+    .task_prio = HTTP_STREAM_TASK_PRIO,          \
+    .stack_in_ext = true,                        \
+    .event_handle = NULL,                        \
+    .user_data = NULL,                           \
+    .auto_connect_next_track = false,            \
+    .enable_playlist_parser = false,             \
+    .multi_out_num = 0,                          \
+    .cert_pem  = NULL,                           \
+    .crt_bundle_attach = NULL,                   \
+    .user_agent = NULL,                          \
+    .buffer_size = HTTP_STREAM_BUFFER_SIZE,      \
+    .buffer_size_tx = HTTP_STREAM_BUFFER_SIZE_TX,\
+}
+#else
 #define HTTP_STREAM_CFG_DEFAULT() {              \
     .type = AUDIO_STREAM_READER,                 \
     .out_rb_size = HTTP_STREAM_RINGBUFFER_SIZE,  \
@@ -122,6 +146,7 @@ typedef struct {
     .user_agent = NULL,                          \
     .buffer_size = HTTP_STREAM_BUFFER_SIZE,      \
 }
+#endif
 
 /**
  * @brief      Create a handle to an Audio Element to stream data from HTTP to another Element


### PR DESCRIPTION
## Description

The http_stream component hardcodes buffer_size (2048) and buffer_size_tx (1024) when creating the internal esp_http_client. This makes it impossible for users to configure these values, thus there is no easy way to fix this error:

```
E (23:53:35.326) HTTP_CLIENT: Out of buffer
```

This PR adds both buffer_size and buffer_size_tx as fields in http_stream_cfg_t, with defaults matching the previous hardcoded values (HTTP_STREAM_BUFFER_SIZE = 2048, HTTP_STREAM_BUFFER_SIZE_TX = 1024). The _http_open() function now reads from the config struct instead of using hardcoded constants.

buffer_size_tx is guarded with #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 1, 0) to match the upstream esp_http_client_config_t field availability.

This is a non-breaking change — existing code using HTTP_STREAM_CFG_DEFAULT() gets the same values as before.

## Testing

Compile and runtime-tested in Willow.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
