### PR TITLE
tidy up audio_sys.c (AUD-7211)

### DIFF
--- a/components/audio_sal/audio_sys.c
+++ b/components/audio_sal/audio_sys.c
@@ -37,19 +37,6 @@ static const char *TAG = "AUDIO_SYS";
 #define ARRAY_SIZE_OFFSET                   8   // Increase this if audio_sys_get_real_time_stats returns ESP_ERR_INVALID_SIZE
 #define AUDIO_SYS_TASKS_ELAPSED_TIME_MS  1000   // Period of stats measurement
 
-const char *task_state[] = {
-    "Running",
-    "Ready",
-    "Blocked",
-    "Suspended",
-    "Deleted"
-};
-
-/** @brief
- * "Extr": Allocated task stack from psram, "Intr": Allocated task stack from internal ram
- */
-const char *task_stack[] = {"Extr", "Intr"};
-
 int audio_sys_get_tick_by_time_ms(int ms)
 {
     return (ms / portTICK_PERIOD_MS);
@@ -66,6 +53,19 @@ int64_t audio_sys_get_time_ms(void)
 esp_err_t audio_sys_get_real_time_stats(void)
 {
 #if (CONFIG_FREERTOS_VTASKLIST_INCLUDE_COREID && CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS)
+    static const char * const task_state[] = {
+        "Running",
+        "Ready",
+        "Blocked",
+        "Suspended",
+        "Deleted"
+    };
+
+    /** @brief
+     * "Extr": Allocated task stack from psram, "Intr": Allocated task stack from internal ram
+     */
+    static const char * const task_stack[] = {"Extr", "Intr"};
+
     TaskStatus_t *start_array = NULL, *end_array = NULL;
     UBaseType_t start_array_size, end_array_size;
     uint32_t start_run_time, end_run_time;


### PR DESCRIPTION
## Description

Clean up spelling, fix an out-of-memory check, and save 7 words of RAM(28B on ESP32).

## Testing

Tested by running examples with and without `CONFIG_FREERTOS_VTASKLIST_INCLUDE_COREID` and `CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS`.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [X] 🚨 This PR does not introduce breaking changes.
- [X] All CI checks (GH Actions) pass.
- [X] Documentation is updated as needed.
- [X] Tests are updated or added as necessary.
- [X] Code is well-commented, especially in complex areas.
- [X] Git history is clean — commits are squashed to the minimum necessary.
