### PR TITLE
update vscode extension create from example document

### DIFF
--- a/docs/en/get-started/index.rst
+++ b/docs/en/get-started/index.rst
@@ -477,11 +477,11 @@ VS Code Extension
 
 2. To install the ESP-ADF extension, open ``Command Palette`` and enter ``install adf``. Then, a progress bar shows up in the lower right corner.
 
-  If you have cloned the ESP-ADF repository before, please enter ``open settings(ui)`` in  ``Command Palette``. Go to ``User > Extensions > ESP_IDF`` and manually set the ESP-ADF path in ``idf.espAdfPath`` or ``idf.espAdfPathWin`` (for Windows). You can also set the ESP-ADF path in ``.vscode/settings.json``.
+  If you have cloned the ESP-ADF repository before, please enter ``open settings(ui)`` in  ``Command Palette``. Go to ``User > Extensions > ESP_IDF`` and manually set the ESP-ADF path in ``idf.customExtraVars`` key-value setting by adding ``ADF_PATH`` as key and the ESP-ADF path as value. You can also set the ESP-ADF path in ``.vscode/settings.json``.
 
-3. In ``Command Palette``, enter ``show examples project``, and then a window will be opened with a list of example projects.
+3. In ``Command Palette``, enter ``new project``, select the ``ESP-IDF: New Project`` option and choose the ESP-IDF version to use. A window will appear with ESP-IDF and ESP-ADF (if you configured using install adf command or adding ADF_PATH in idf.customExtraVars setting) sections. Expand ESP-ADF and choose desired example from the list of example projects.
 
-4. Select an example, click ``Create project using example XX``, and select the directory to save the current example.
+4. Select an example, click ``Create project using example XX``, and later configure the new project to be created such as the directory to save, the project name, and other settings.
 
 5. On the toolbar at the bottom of VS Code, click the gear symbol ``menuconfig`` to configure the example and click the column symbol ``Build`` to build the example. See available `shortcut keys <https://github.com/espressif/vscode-esp-idf-extension#available-commands>`_ for VS code extensions.
 


### PR DESCRIPTION


## Description

This pull request updates the VS Code Extension setup instructions in the ESP-ADF documentation to reflect recent changes in configuration and workflow. The most important changes clarify how to set the ESP-ADF path and update the process for creating new projects from examples.

**Documentation and workflow updates:**

* Updated instructions for setting the ESP-ADF path: users should now set the path using the `idf.customExtraVars` setting with `ADF_PATH` as the key, instead of the previous `idf.espAdfPath` or `idf.espAdfPathWin` settings.
* Revised the process for creating new projects: users now use the `new project` command, select the ESP-IDF version, and choose ESP-ADF examples if configured, with additional configuration options for the new project (directory, name, etc.).

## Related

[VS Code extension for ESP-IDF Start a project documentation](https://docs.espressif.com/projects/vscode-esp-idf-extension/en/latest/startproject.html)

## Testing

Documentation change.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
