### PR TITLE
release v2x update vscode extension create from example document

### DIFF
--- a/docs/en/get-started/index.rst
+++ b/docs/en/get-started/index.rst
@@ -477,11 +477,11 @@ VS Code Extension
 
 2. To install the ESP-ADF extension, open ``Command Palette`` and enter ``install adf``. Then, a progress bar shows up in the lower right corner.
 
-  If you have cloned the ESP-ADF repository before, please enter ``open settings(ui)`` in  ``Command Palette``. Go to ``User > Extensions > ESP_IDF`` and manually set the ESP-ADF path in ``idf.espAdfPath`` or ``idf.espAdfPathWin`` (for Windows). You can also set the ESP-ADF path in ``.vscode/settings.json``.
+  If you have cloned the ESP-ADF repository before, please enter ``open settings(ui)`` in  ``Command Palette``. Go to ``User > Extensions > ESP_IDF`` and manually set the ESP-ADF path in ``idf.customExtraVars`` key-value setting by adding ``ADF_PATH`` as key and the ESP-ADF path as value. You can also set the ESP-ADF path in ``.vscode/settings.json``.
 
-3. In ``Command Palette``, enter ``show examples project``, and then a window will be opened with a list of example projects.
+3. In ``Command Palette``, enter ``new project``, select the ``ESP-IDF: New Project`` option and choose the ESP-IDF version to use. A window will appear with ESP-IDF and ESP-ADF (if you configured using install adf command or adding ADF_PATH in idf.customExtraVars setting) sections. Expand ESP-ADF and choose desired example from the list of example projects.
 
-4. Select an example, click ``Create project using example XX``, and select the directory to save the current example.
+4. Select an example, click ``Create project using example XX``, and later configure the new project to be created such as the directory to save, the project name, and other settings.
 
 5. On the toolbar at the bottom of VS Code, click the gear symbol ``menuconfig`` to configure the example and click the column symbol ``Build`` to build the example. See available `shortcut keys <https://github.com/espressif/vscode-esp-idf-extension#available-commands>`_ for VS code extensions.
 


### PR DESCRIPTION
## Description

This pull request updates the ESP-ADF setup instructions in the VS Code Extension documentation to reflect recent changes in recommended configuration and project creation workflows. The changes clarify how to set the ESP-ADF path and provide more detailed steps for creating new projects using the extension.

**Documentation updates:**

* Updated the instructions for setting the ESP-ADF path to recommend using the `idf.customExtraVars` setting with the `ADF_PATH` key, instead of the old `idf.espAdfPath` or `idf.espAdfPathWin` settings.
* Revised the project creation steps to use the `ESP-IDF: New Project` command, and clarified the process for selecting ESP-ADF examples and configuring new projects.

## Related

[VS Code extension for ESP-IDF Start a project documentation](https://docs.espressif.com/projects/vscode-esp-idf-extension/en/latest/startproject.html)

## Testing

Documentation change.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
