### PR TITLE
Add missing include in codec_dev ADC 

### DIFF
--- a/components/esp_codec_dev/CHANGELOG.md
+++ b/components/esp_codec_dev/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.5.11
+
+### Bug Fixed
+
+- Fixed dependencies of ADC codec header file
+
 ## v1.5.10
 
 ### Bug Fixed

--- a/components/esp_codec_dev/idf_component.yml
+++ b/components/esp_codec_dev/idf_component.yml
@@ -1,4 +1,4 @@
-version: 1.5.10
+version: 1.5.11
 description: Audio codec device support for Espressif SOC
 url: https://github.com/espressif/esp-adf/tree/master/components/esp_codec_dev
 

--- a/components/esp_codec_dev/include/esp_codec_adc.h
+++ b/components/esp_codec_dev/include/esp_codec_adc.h
@@ -9,6 +9,7 @@
 
 #ifdef CONFIG_CODEC_DATA_ADC_SUPPORT
 
+#include "audio_codec_data_if.h"
 #include "esp_idf_version.h"
 #include "soc/soc_caps.h"
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0) && SOC_ADC_SUPPORTED


### PR DESCRIPTION
## Description

Added a missing include to `esp_codec_adc.h`.
This header file uses `audio_codec_data_if_t` typedef which is defined in `audio_codec_data_if.h`. 
When the  `esp_codec_adc.h` header file is included after another `esp_codec_dev` header then this code compiles otherwise there is a compilation error.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
